### PR TITLE
[FEAT] #8 - 헤더 및 푸터 구현

### DIFF
--- a/public/images/logo1.svg
+++ b/public/images/logo1.svg
@@ -1,0 +1,44 @@
+<svg width="120" height="26" viewBox="0 0 120 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_784_532)">
+<path d="M106.909 3.70637C107.904 3.70637 108.711 2.89307 108.711 1.88981C108.711 0.886546 107.904 0.0732422 106.909 0.0732422C105.913 0.0732422 105.106 0.886546 105.106 1.88981C105.106 2.89307 105.913 3.70637 106.909 3.70637Z" fill="#FFE91D"/>
+<path d="M113.396 3.70637C114.391 3.70637 115.198 2.89307 115.198 1.88981C115.198 0.886546 114.391 0.0732422 113.396 0.0732422C112.401 0.0732422 111.594 0.886546 111.594 1.88981C111.594 2.89307 112.401 3.70637 113.396 3.70637Z" fill="#FFE91D"/>
+<path d="M6.95918 5.20044H0V0.000488281H20.1502V5.20044H13.1566V26.0005H6.95918V5.20044Z" fill="#FFE91D"/>
+<path d="M22.0587 0.000488281H31.5105C37.0156 0.000488281 41.5856 1.9199 41.5856 8.2019C41.5856 12.006 39.8199 14.4488 37.1538 15.7053L42.9013 26.0005H35.977L31.2336 16.8568H28.256V26.0005H22.0586V0.000488281H22.0587ZM31.0258 11.9361C33.9687 11.9361 35.5613 10.645 35.5613 8.2019C35.5613 5.75884 33.9687 4.95621 31.0258 4.95621H28.256V11.9363H31.0258V11.9361Z" fill="#FFE91D"/>
+<path d="M50.7319 0.000488281H56.9293L51.0099 26.0005H44.8125L50.7319 0.000488281Z" fill="#FFE91D"/>
+<path d="M59.8096 0.000488281H68.8806C74.524 0.000488281 79.198 2.05956 79.198 8.48099C79.198 14.9024 74.4897 17.3804 69.0191 17.3804H66.0066V26.0006H59.8096V0.000488281ZM68.7077 12.4595C71.7197 12.4595 73.1736 11.0286 73.1736 8.48088C73.1736 5.93314 71.5121 4.95611 68.5344 4.95611H66.0066V12.4595H68.7077Z" fill="#FFE91D"/>
+<path d="M107.294 26.0007V14.1372H113.783V26.0007H107.294Z" fill="#FFE91D"/>
+<path d="M36.3865 4.34082H27.1641V12.76H36.3865V4.34082Z" fill="#FFE91D"/>
+<path d="M74.5789 4.34082H65.3564V12.76H74.5789V4.34082Z" fill="#FFE91D"/>
+<path d="M105.481 6.44824H100.306C100.306 11.9302 104.714 16.3742 110.153 16.3742V11.5098C107.165 11.3295 105.481 9.6132 105.481 6.44824H105.481Z" fill="#FFE91D"/>
+<path d="M114.825 6.44824H120C120 11.9302 115.592 16.3742 110.153 16.3742V11.5098C113.142 11.3295 114.825 9.6132 114.825 6.44824H114.825Z" fill="#FFE91D"/>
+<path d="M83.0234 13.6738L91.076 13.9378" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M85.2178 8.79053L90.7267 14.7168" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M90.1955 6.90088L89.9336 15.0179" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M95.0394 9.11182L89.1602 14.6647" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M96.913 14.1287L88.8604 13.8647" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M94.7208 19.0122L89.2119 13.0859" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M89.7422 20.9021L90.0041 12.7852" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M84.8984 18.6912L90.7777 13.1382" stroke="#0DC6FF" stroke-width="1.07068" stroke-miterlimit="10"/>
+<path d="M67.0615 8.61719L70.2397 8.72144" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M67.9268 6.68994L70.1011 9.02896" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M69.8914 5.94482L69.7881 9.14842" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M71.8039 6.81689L69.4834 9.0086" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M72.5444 8.79702L69.3662 8.69287" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M71.6772 10.7238L69.5029 8.38477" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M69.7139 11.4697L69.8172 8.26611" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M67.8008 10.5974L70.1212 8.40576" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M28.0781 8.72705L31.258 8.72697" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M28.8818 6.77197L31.1305 9.03849" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M30.8191 5.96243L30.8192 9.16783" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M32.7597 6.77209L30.5111 9.03858" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M33.5638 8.72659L30.3838 8.72656" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M32.7602 10.682L30.5117 8.41553" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M30.8192 11.4915L30.8192 8.28616" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+<path d="M28.8822 10.6813L31.1308 8.41467" stroke="white" stroke-width="0.535338" stroke-miterlimit="10"/>
+</g>
+<defs>
+<clipPath id="clip0_784_532">
+<rect width="120" height="26" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/images/logo2.svg
+++ b/public/images/logo2.svg
@@ -1,0 +1,44 @@
+<svg width="108" height="24" viewBox="0 0 108 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_784_2679)">
+<path d="M96.2196 3.42202C97.1154 3.42202 97.8415 2.67127 97.8415 1.74519C97.8415 0.819101 97.1154 0.0683594 96.2196 0.0683594C95.3238 0.0683594 94.5977 0.819101 94.5977 1.74519C94.5977 2.67127 95.3238 3.42202 96.2196 3.42202Z" fill="#262626"/>
+<path d="M102.057 3.42202C102.953 3.42202 103.679 2.67127 103.679 1.74519C103.679 0.819101 102.953 0.0683594 102.057 0.0683594C101.162 0.0683594 100.436 0.819101 100.436 1.74519C100.436 2.67127 101.162 3.42202 102.057 3.42202Z" fill="#262626"/>
+<path d="M6.26326 4.79996H0V0H18.1352V4.79996H11.8409V24H6.26326V4.79996Z" fill="#262626"/>
+<path d="M19.8536 0H28.3603C33.3148 0 37.4278 1.77177 37.4278 7.57053C37.4278 11.082 35.8387 13.3369 33.4392 14.4967L38.612 24H32.38L28.1111 15.5597H25.4312V24H19.8535V0H19.8536ZM27.924 11.0175C30.5726 11.0175 32.006 9.82566 32.006 7.57053C32.006 5.3154 30.5726 4.57452 27.924 4.57452H25.4312V11.0176H27.924V11.0175Z" fill="#262626"/>
+<path d="M45.6576 0H51.2352L45.9077 24H40.3301L45.6576 0Z" fill="#262626"/>
+<path d="M53.8301 0H61.994C67.0731 0 71.2797 1.90068 71.2797 7.82815C71.2797 13.7556 67.0422 16.043 62.1187 16.043H59.4074V24.0001H53.8301V0ZM61.8384 11.5006C64.5492 11.5006 65.8577 10.1798 65.8577 7.82805C65.8577 5.47629 64.3623 4.57442 61.6824 4.57442H59.4074V11.5006H61.8384Z" fill="#262626"/>
+<path d="M96.5645 24.0007V13.0498H102.404V24.0007H96.5645Z" fill="#262626"/>
+<path d="M32.7475 4.00684H24.4473V11.7784H32.7475V4.00684Z" fill="#262626"/>
+<path d="M67.1205 4.00684H58.8203V11.7784H67.1205V4.00684Z" fill="#262626"/>
+<path d="M94.933 5.95215H90.2754C90.2754 11.0124 94.2432 15.1145 99.1378 15.1145V10.6244C96.4484 10.4579 94.9329 8.87365 94.9329 5.95215H94.933Z" fill="#262626"/>
+<path d="M103.343 5.95215H108.001C108.001 11.0124 104.033 15.1145 99.1387 15.1145V10.6244C101.828 10.4579 103.344 8.87365 103.344 5.95215H103.343Z" fill="#262626"/>
+<path d="M74.7207 12.6221L81.968 12.8657" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M76.6953 8.11523L81.6534 13.5856" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M81.1752 6.37012L80.9395 13.8627" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M85.5355 8.41211L80.2441 13.5378" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M87.222 13.0425L79.9746 12.7988" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M85.247 17.5505L80.2891 12.0801" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M80.7676 19.2943L81.0033 11.8018" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M76.4082 17.2528L81.6996 12.127" stroke="#262626" stroke-width="0.972531" stroke-miterlimit="10"/>
+<path d="M60.3555 7.95508L63.2158 8.05131" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M61.1328 6.1748L63.0897 8.3339" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M62.9024 5.48828L62.8086 8.44544" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M64.6236 6.29297L62.5352 8.31608" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M65.2881 8.12055L62.4277 8.02441" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M64.5095 9.89933L62.5527 7.74023" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M62.7422 10.588L62.836 7.63086" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M61.0215 9.78278L63.1098 7.75977" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M25.2695 8.05566L28.1314 8.05559" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M25.9941 6.25098L28.0179 8.34315" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M27.7403 5.50368L27.7395 8.46256" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M29.4838 6.25108L27.4601 8.34323" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M30.2057 8.05569L27.3438 8.05566" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M29.4846 9.85975L27.4609 7.76758" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M27.7395 10.608L27.7404 7.64919" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+<path d="M25.9933 9.86091L28.017 7.76866" stroke="white" stroke-width="0.486266" stroke-miterlimit="10"/>
+</g>
+<defs>
+<clipPath id="clip0_784_2679">
+<rect width="108" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
+import Header from '@/components/layout/header';
+import Footer from '@/components/layout/footer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -15,7 +17,11 @@ export default function RootLayout({
 }) {
     return (
         <html lang='en'>
-            <body className={inter.className}>{children}</body>
+            <body className={inter.className}>
+                <Header />
+                {children}
+                <Footer />
+            </body>
         </html>
     );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link"
+
+export default function Footer () {
+    return (
+        <footer className="bg-white h-248">
+            <div className="container my-5 flex flex-col items-start justify-center h-full p-6">
+                <div className="flex items-start space-x-8">
+                    <img className="w-108 h=24 " src="/images/logo2.svg" alt="트리피 흑백 로고"></img>
+                    <nav className="space-x-3 flex flex-row">
+                        <Link href="/">회사소개</Link>
+                        <Link href="/">고객센터</Link>
+                        <Link href="/">이용약관</Link>
+                        <Link href="/">개인정보 처리방침</Link>
+                        <Link href="/">저작권 표기</Link>
+                    </nav>
+                </div>
+                <div className="flex flex-col pt-10">
+                    <a>(주)트리피 사업자 정보</a>
+                    <a>상호: 트리피</a>
+                    <a>사업자등록번호: 999-99-99999</a>
+                    <a>이메일: contact@tripy.net</a>
+                </div>
+            </div>
+        </footer>
+    )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 interface MenuProps {
     menu: string;
@@ -24,7 +24,7 @@ export default function Header () {
 
     // 메뉴바 선택항목 상태구현
     const [menus, setMenus] = useState<[string, boolean][]>([
-        ['여행정보', true],
+        ['여행정보', false],
         ['일정관리', false],
         ['여행가방', false],
         ['커뮤니티', false],
@@ -82,20 +82,27 @@ export default function Header () {
                         ))}
                     </nav>
                 </div>
+                <div className="flex items-center space-x-6">
                     {isLoggedIn ? (
-                        <div className="flex items-center space-x-6">
-                            <Link href='/'>마이페이지</Link>
-                            <Link href='/info' onClick={handleLogout}>로그아웃</Link>
+                        <>
+                            <Link href='/mypage'>마이페이지</Link>
+                            <button onClick={handleLogout} className="focus:outline-none">
+                                로그아웃
+                            </button>
                             <Link href='/'>
                                 <img className='w-12 h-12' src='/images/user.svg' alt="프로필 사진" />
                             </Link>
-                        </div>
+                        </>
                     ) : (
-                        <div className="flex items-center space-x-6">
-                            <Link href='/info' onClick={handleLogin}>로그인</Link>
+                        <>
+                        
+                            <button onClick={handleLogin} className="focus:outline-none">
+                                로그인
+                            </button>
                             <Link href='/'>회원가입</Link>
-                        </div>
+                        </>
                     )}
+                </div>
             </div>
         </header>
     );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+export default function Header () {
+    return (
+        <header className='x-0 top-0 z-50 left-0 w-full  bg-white border-b border-gray-300'>
+            <div className='container my-1.5 flex items-center justify-between flex-wrap p-5'>
+                <div className="flex items-center space-x-8">
+                    <Link href='/' className="flex items-center space-x-2">
+                        <img className='w-120' src='/images/logo1.svg' alt="트리피 로고" />
+                    </Link>
+                    <nav className="space-x-4">
+                        <Link href="/">여행정보</Link>
+                        <Link href="/">일정관리</Link>
+                        <Link href="/">여행가방</Link>
+                        <Link href="/">커뮤니티</Link>
+                        <Link href="/">이용안내</Link>
+                    </nav>
+                </div>
+                <div className="flex items-center space-x-4">
+                    <Link href='/'>마이페이지</Link>
+                    <Link href='/'>로그아웃</Link>
+                    <Link href='/'>
+                        <img className='w-12 h-12' src='/images/user.svg' alt="프로필 사진" />
+                    </Link>
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -33,10 +33,10 @@ export default function Header () {
 
     const Menu = ({ menu, select, index, onClick }: MenuProps) => {
         return (
-            <div className='flex flex-col items-center'>
+            <div className='relative flex flex-col items-center'>
                 {select && (
                     <img
-                        className='block'
+                        className='absolute top-0 transform -translate-y-full'
                         src='/images/selected.png'
                         alt='none'
                     />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,28 +1,101 @@
+'use client';
+
 import Link from "next/link";
+import React, { useEffect, useState } from "react";
+
+interface MenuProps {
+    menu: string;
+    select: boolean;
+    index: number;
+    onClick: (index: number) => void;
+}
 
 export default function Header () {
+    // 로그인, 로그아웃 상태구현
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+    const handleLogin = () => {
+        setIsLoggedIn(true);
+    };
+
+    const handleLogout = () => {
+        setIsLoggedIn(false);
+    }
+
+    // 메뉴바 선택항목 상태구현
+    const [menus, setMenus] = useState<[string, boolean][]>([
+        ['여행정보', true],
+        ['일정관리', false],
+        ['여행가방', false],
+        ['커뮤니티', false],
+        ['이용안내', false],
+    ]);
+
+    const Menu = ({ menu, select, index, onClick }: MenuProps) => {
+        return (
+            <div className='flex flex-col items-center'>
+                {select && (
+                    <img
+                        className='block'
+                        src='/images/selected.png'
+                        alt='none'
+                    />
+                )}
+                <span
+                    className={
+                        select
+                            ? 'font-bold hover:cursor-pointer'
+                            : 'hover:cursor-pointer'
+                    }
+                    onClick={() => onClick(index)}
+                >
+                    {menu}
+                </span>
+            </div>
+        );
+    };
+
+    const menuClick = (selectedIndex: number) => {
+        const updatedMenus: [string, boolean][] = menus.map((menu, index) => [
+            menu[0],
+            index === selectedIndex
+        ]);
+        setMenus(updatedMenus);
+    };
+
     return (
-        <header className='x-0 top-0 z-50 left-0 w-full  bg-white border-b border-gray-300'>
-            <div className='container my-1.5 flex items-center justify-between flex-wrap p-5'>
-                <div className="flex items-center space-x-8">
-                    <Link href='/' className="flex items-center space-x-2">
+        <header className='x-0 top-0 z-50 left-0 w-full bg-white border-b border-gray-300'>
+            <div className='container mx-auto my-0.5 h-24 flex justify-between flex-wrap p-5'>
+                <div className="flex space-x-16">
+                    <Link href='/' className="flex">
                         <img className='w-120' src='/images/logo1.svg' alt="트리피 로고" />
                     </Link>
-                    <nav className="space-x-4">
-                        <Link href="/">여행정보</Link>
-                        <Link href="/">일정관리</Link>
-                        <Link href="/">여행가방</Link>
-                        <Link href="/">커뮤니티</Link>
-                        <Link href="/">이용안내</Link>
+                    <nav className="flex items-center space-x-8">
+                        {menus.map((menu, index) => (
+                            <Menu
+                                key={`menu${index}`}
+                                menu={menu[0]}
+                                select={menu[1]}
+                                index={index}
+                                onClick={menuClick}
+                            />
+                        ))}
                     </nav>
                 </div>
-                <div className="flex items-center space-x-4">
-                    <Link href='/'>마이페이지</Link>
-                    <Link href='/'>로그아웃</Link>
-                    <Link href='/'>
-                        <img className='w-12 h-12' src='/images/user.svg' alt="프로필 사진" />
-                    </Link>
-                </div>
+                    {isLoggedIn ? (
+                        <div className="flex items-center space-x-6">
+                            <Link href='/'>마이페이지</Link>
+                            <Link href='/info' onClick={handleLogout}>로그아웃</Link>
+                            <Link href='/'>
+                                <img className='w-12 h-12' src='/images/user.svg' alt="프로필 사진" />
+                            </Link>
+                        </div>
+                    ) : (
+                        <div className="flex items-center space-x-6">
+                            <Link href='/info' onClick={handleLogin}>로그인</Link>
+                            <Link href='/'>회원가입</Link>
+                        </div>
+                    )}
             </div>
         </header>
     );


### PR DESCRIPTION
🚩 관련 이슈
[FEAT] #8 - 헤더 및 푸터 구현

📋 PR Checklist
- [ ] 헤더 및 푸터 구현
- [ ] 헤더 메뉴바 선택 스타일링
- [ ] 헤더 로그인, 로그아웃 버튼 구현

📌 유의사항
- 헤더를 fixed로 설정 시 컨텐츠가 가려져서 헤더 폭 100px만큼의 마진을 줘야할 것 같은데, 요 부분은 헤더를 고정으로 할 지 디자이너분과 한번 상의해봐야 할 것 같습니다.
- 우선 구현을 위해 app/layout.tsx에 헤더와 푸터 컴포넌트를 넣었습니다.
- 마이페이지 버튼 링크를 /mypage로 설정했는데 추후 해당 페이지 구현 예정

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/c34364a6-5ac4-4d4f-8132-62c6276dc114)
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/ff05a646-3499-4114-b6cf-d39b76e2a658)
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/bf44ff81-31d1-437f-8937-cb999e837cd5)

