### PR TITLE
[Feat] #16 - 환율 계산 기능 및 캘린더 일부 구현

### DIFF
--- a/src/components/infocity/ExchangeRate.tsx
+++ b/src/components/infocity/ExchangeRate.tsx
@@ -5,25 +5,61 @@ export default function ExchangeRate() {
     const [before, setBefore] = useState<string>('');
     const [after, setAfter] = useState<string>(before);
     const [isWon, setIsWon] = useState<boolean>(true);
+
+    // 한국 돈 => 외국 돈
+    const wonToOther = (inputValue: string) => {
+        let temp = (Number(inputValue) / 9.21).toFixed(2);
+        let a = Number(temp.substring(0, temp.indexOf('.'))).toLocaleString();
+        let b = temp.substring(temp.indexOf('.'), temp.length);
+        return a + b;
+    };
+
+    // 외국 돈 => 한국 돈
+    const otherToWon = (inputValue: string) => {
+        return Number((Number(inputValue) * 9.21).toFixed(0)).toLocaleString();
+    };
+
+    const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const inputValue = e.target.value.replace(/[^0-9]/g, ''); // 숫자 이외의 문자 제거
+        // 문자열에서 콤마 제거
+        inputValue.replace(/,/g, '');
+        const temp = Number(inputValue).toLocaleString();
+        setBefore(temp);
+        const send = isWon ? wonToOther(inputValue) : otherToWon(inputValue);
+        setAfter(send);
+    };
     return (
         <div className='flex justify-between items-center mt-3'>
-            {/* 환율 api 연동 해야합니다, input에 숫자만 입력하는 방법 찾아보는 중 입니다*/}
+            {/* 환율 api 연동 해야합니다 */}
             <div className='flex'>
                 <div className='flex flex-col justify-center text-center bg-lightgrey text-darkgrey rounded-l w-24 h-16'>
                     <div>{isWon ? '대한민국' : '일본'}</div>
                     <div>{isWon ? 'KRW' : 'JPY'}</div>
                 </div>
                 <input
-                    className='flex flex-col justify-center text-center text-right border border-lightgrey rounded-r w-60 px-3'
+                    className={
+                        before === ''
+                            ? 'flex flex-col justify-center text-center text-right border border-lightgrey rounded-r w-60 px-3'
+                            : 'flex flex-col justify-center text-center text-right border border-lightgrey rounded-r w-60 px-[25px]'
+                    }
                     type='text'
                     placeholder='숫자를 입력해주세요.'
                     value={before}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        setBefore(e.target.value);
-                    }}
+                    onChange={onChange}
+                    maxLength={15} // 1000조 이하까지 계산
                 />
+                <div
+                    className={
+                        before === ''
+                            ? 'hidden'
+                            : 'self-center absolute ml-[310px]'
+                    }
+                >
+                    {isWon ? '원' : '엔'}
+                </div>
             </div>
             <LiaExchangeAltSolid
+                className='hover:cursor-pointer'
                 size={28}
                 onClick={() => {
                     setIsWon(!isWon);
@@ -37,7 +73,8 @@ export default function ExchangeRate() {
                     <div>{isWon ? 'JPY' : 'KRW'}</div>
                 </div>
                 <div className='flex flex-col justify-center text-center text-right border border-lightgrey rounded-r w-60 px-3'>
-                    {after}
+                    {before === '' ? 0 : after}
+                    {isWon ? '엔' : '원'}
                 </div>
             </div>
         </div>

--- a/src/components/infocity/InfoCity.tsx
+++ b/src/components/infocity/InfoCity.tsx
@@ -1,22 +1,73 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { IoThunderstormOutline } from 'react-icons/io5';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import InfoWeather from './InfoWeather';
 import ExchangeRate from './ExchangeRate';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { ko } from 'date-fns/locale';
+import format from 'date-fns/format';
 
 export default function InfoCity() {
+    const [startDate, setStartDate] = useState<null | Date>(null);
+    const [endDate, setEndDate] = useState<null | Date>(null);
+    const [isOpen, setIsOpen] = useState<boolean>(false);
     const temperatures = [
         ['16º', '1º', '1~3월'],
         ['16º', '1º', '4~6월'],
         ['16º', '1º', '7~9월'],
         ['16º', '1º', '10~12월']
     ];
-    const SelectDates = ({ title }: { title: string }) => {
+    const SelectDates = ({
+        title,
+        value
+    }: {
+        title: null | string;
+        value: null | Date;
+    }) => {
         return (
-            <div className='flex items-center justify-between px-5 h-16 w-80 text-grey border border-lightgrey rounded-l'>
-                {title}
+            <div
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                    e.preventDefault();
+                    setIsOpen(!isOpen);
+                }}
+                className='flex items-center justify-between px-5 h-16 w-80 text-grey border border-lightgrey rounded-l hover:cursor-pointer'
+            >
+                {value === null ? title : format(value, 'yyyy-MM-dd')}
                 <AiOutlineCalendar size={24} />
             </div>
+        );
+    };
+    const onChange = (dates: any) => {
+        const [start, end] = dates;
+        setStartDate(start);
+        setEndDate(end);
+    };
+    useEffect(() => {
+        endDate === null ? setIsOpen(isOpen) : setIsOpen(!isOpen);
+    }, [endDate]);
+    window.onload = () => {
+        let weekends = document.getElementsByClassName(
+            'react-datepicker__day-name'
+        );
+        Object.values(weekends).filter((weekend) =>
+            weekend.innerHTML === '일'
+                ? (weekend.style.color = 'red')
+                : weekend.innerHTML === '토'
+                ? (weekend.style.color = 'blue')
+                : ''
+        );
+        let weekendsColor = document.getElementsByClassName(
+            'react-datepicker__day--weekend'
+        );
+        console.log(
+            Object.values(weekendsColor).filter((weekend) =>
+                weekend.ariaLabel?.indexOf('일요일') !== -1
+                    ? (weekend.style.color = 'red')
+                    : weekend.ariaLabel?.indexOf('토요일') !== -1
+                    ? (weekend.style.color = 'blue')
+                    : ''
+            )
         );
     };
     return (
@@ -52,8 +103,8 @@ export default function InfoCity() {
                 <div className=''>
                     <span className='text-2xl'>여행계획을 시작해볼까요?</span>
                     <div className='flex mt-3'>
-                        <SelectDates title='출발일' />
-                        <SelectDates title='도착일' />
+                        <SelectDates title='출발일' value={startDate} />
+                        <SelectDates title='도착일' value={endDate} />
                         <button
                             type='button'
                             className='w-auto  bg-black text-white rounded-r px-4'
@@ -61,6 +112,25 @@ export default function InfoCity() {
                             로그인하기
                         </button>
                     </div>
+                </div>
+                <div
+                    className={
+                        isOpen
+                            ? 'block absolute mt-[522px] ml-[80px]'
+                            : 'hidden'
+                        // 'block absolute'
+                    }
+                >
+                    <DatePicker
+                        dateFormatCalendar='yyyy년 MM월'
+                        selected={startDate}
+                        onChange={onChange}
+                        startDate={startDate}
+                        endDate={endDate}
+                        selectsRange
+                        inline
+                        locale={ko}
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/infomenu/InfoMenus.tsx
+++ b/src/components/infomenu/InfoMenus.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { BiSearch } from 'react-icons/bi';
 
 interface MenuProps {
@@ -16,6 +16,7 @@ export default function InfoMenus() {
         ['후기', false],
         ['회화', false]
     ]);
+    const [place, setPlace] = useState<string>('');
 
     const Menu = ({ menu, select, index, onClick }: MenuProps) => {
         return (
@@ -50,7 +51,7 @@ export default function InfoMenus() {
     };
 
     return (
-        <div className='flex justify-between'>
+        <div className='flex justify-between mt-6'>
             <div className='flex items-end'>
                 {menus.map((menu, index) => (
                     <Menu
@@ -67,8 +68,20 @@ export default function InfoMenus() {
                     className='border border-grey w-96 h-14 rounded-lg py-3.5 pl-6'
                     type='text'
                     placeholder='보고 싶은 여행지를 입력하세요'
+                    value={place}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        setPlace(e.target.value)
+                    }
                 />
-                <BiSearch size='24' className='absolute self-end mr-5' />
+                <BiSearch
+                    onClick={() =>
+                        place === ''
+                            ? alert('1글자 이상 입력해주세요.')
+                            : alert(`${place} 검색 중...`)
+                    }
+                    size='24'
+                    className='absolute self-end mr-5 hover:cursor-pointer'
+                />
             </div>
         </div>
     );


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #16 - 환율 계산 기능 및 캘린더 일부 구현

📋 PR Checklist
- [x] 환율 계산 잘 되는지 확인(어제(23.7.11) 환율 기준으로 계산했습니다)
- [x] 출발일 또는 도착일 눌렀을 때 캘린더 나오고 날짜 범위 선택 잘 되는지 확인

📌 유의사항
- 날씨, 환율 및 캘린더 작업은 추후에 더 할 예정입니다.

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
