### PR TITLE
[FEAT] 카카오 소셜 로그인

### DIFF
--- a/src/app/auth/google/page.tsx
+++ b/src/app/auth/google/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getAuthCode } from '@/utils/google';
+import { splitAuthCode } from '@/utils/oauth';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -10,10 +10,15 @@ const GoogleOAuth = () => {
 
     useEffect(() => {
         // TODO: authCode를 서버에 넘겨준 다음 200 받으면 메인 페이지로 이동
-        getAuthCode().then((res) => setAuthCode(res));
-        router.push('/');
+        splitAuthCode().then((res) => setAuthCode(res));
+        // router.push('/');
     }, []);
-    return <div>인가코드 리다이렉트 페이지</div>;
+    return (
+        <div>
+            <div>구글 리다이렉트 페이지</div>
+            <div>{authCode}</div>
+        </div>
+    );
 };
 
 export default GoogleOAuth;

--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { splitAuthCode } from '@/utils/oauth';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const KakaoOAuth = () => {
+    const [authCode, setAuthCode] = useState<string>();
+    const router = useRouter();
+
+    useEffect(() => {
+        // TODO: authCode를 서버에 넘겨준 다음 200 받으면 메인 페이지로 이동
+        splitAuthCode().then((res) => setAuthCode(res));
+        // router.push('/');
+    }, []);
+    return (
+        <div>
+            <div>카카오 리다이렉트 페이지</div>
+            <div>{authCode}</div>
+        </div>
+    );
+};
+
+export default KakaoOAuth;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import { Inter } from 'next/font/google';
 import Header from '@/components/layout/header';
 import Footer from '@/components/layout/footer';
+import Script from 'next/script';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -17,6 +18,7 @@ export default function RootLayout({
 }) {
     return (
         <html lang='en'>
+            <Script src='https://developers.kakao.com/sdk/js/kakao.js'></Script>
             <body id='body' className={inter.className}>
                 {/* <div className='modal absolute top-1/4 left-1/4'></div> */}
                 <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import Community from '@/components/community/Community';
 import CardCarousel from '@/components/main/CardCarousel';
 
 import GoogleLoginButton from '@/components/button/GoogleLoginButton';
+import KakaoLoginButton from '@/components/button/KakaoLoginButton';
 
 import ILocation from '@/models/interface/Ilocation';
 import { FiThumbsUp, FiEye } from 'react-icons/fi';
@@ -325,6 +326,7 @@ export default function Home() {
                     <div className='p-5'>
                         모달창 테스트, 여기에 원하는 화면을 구현해 넣어주세요.
                         <GoogleLoginButton />
+                        <KakaoLoginButton />
                     </div>
                 </Modal>
             )} */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -318,15 +318,26 @@ export default function Home() {
             {modal && (
                 <Modal
                     modalMode={1}
-                    title='회원가입 하기'
+                    title='로그인 하기'
                     setModalState={setModal}
                     onClickCompleteButton={() => setModal(false)}
-                    completeText='로그인'
+                    completeText='X'
                 >
-                    <div className='p-5'>
-                        모달창 테스트, 여기에 원하는 화면을 구현해 넣어주세요.
-                        <KakaoLoginButton />
-                        <GoogleLoginButton />
+                    <div className='flex flex-col'>
+                        <div className='flex flex-col gap-4 justify-center h-4/5 p-5'>
+                            <KakaoLoginButton />
+                            <GoogleLoginButton />
+                        </div>
+                        <div className='text-xs text-center text-grey mt-4 p-5'>
+                            소셜 로그인으로 가입 시&nbsp;
+                            <span className='text-kakao-color'>
+                                이용약관, 개인정보처리방침, 전자금융거래약관
+                            </span>
+                            에 동의함으로 처리됩니다.
+                        </div>
+                        <div className='flex justify-center items-center pt-4 h-1/6 border-t border-lightgrey cursor-pointer'>
+                            회원가입
+                        </div>
                     </div>
                 </Modal>
             )} */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -325,8 +325,8 @@ export default function Home() {
                 >
                     <div className='p-5'>
                         모달창 테스트, 여기에 원하는 화면을 구현해 넣어주세요.
-                        <GoogleLoginButton />
                         <KakaoLoginButton />
+                        <GoogleLoginButton />
                     </div>
                 </Modal>
             )} */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import CardCarousel from '@/components/main/CardCarousel';
 import GoogleLoginButton from '@/components/button/GoogleLoginButton';
 import KakaoLoginButton from '@/components/button/KakaoLoginButton';
 
-import ILocation from '@/models/interface/Ilocation';
+import ILocation from '@/models/interface/ILocation';
 import { FiThumbsUp, FiEye } from 'react-icons/fi';
 
 const dummyItem = <div>abc</div>;
@@ -125,7 +125,6 @@ const dummyCommunity = [
 ];
 
 export default function Home() {
-    const [modal, setModal] = useState(false);
     const [isAbroad, setIsAbroad] = useState<boolean>(true);
 
     return (
@@ -313,34 +312,6 @@ export default function Home() {
                     <span className='text-xl'>프로모션 부가설명</span>
                 </div>
             </div>
-
-            {/* <button onClick={() => setModal(true)}>모달 예시 버튼</button>
-            {modal && (
-                <Modal
-                    modalMode={1}
-                    title='로그인 하기'
-                    setModalState={setModal}
-                    onClickCompleteButton={() => setModal(false)}
-                    completeText='X'
-                >
-                    <div className='flex flex-col'>
-                        <div className='flex flex-col gap-4 justify-center h-4/5 p-5'>
-                            <KakaoLoginButton />
-                            <GoogleLoginButton />
-                        </div>
-                        <div className='text-xs text-center text-grey mt-4 p-5'>
-                            소셜 로그인으로 가입 시&nbsp;
-                            <span className='text-kakao-color'>
-                                이용약관, 개인정보처리방침, 전자금융거래약관
-                            </span>
-                            에 동의함으로 처리됩니다.
-                        </div>
-                        <div className='flex justify-center items-center pt-4 h-1/6 border-t border-lightgrey cursor-pointer'>
-                            회원가입
-                        </div>
-                    </div>
-                </Modal>
-            )} */}
         </main>
     );
 }

--- a/src/components/button/GoogleLoginButton.tsx
+++ b/src/components/button/GoogleLoginButton.tsx
@@ -1,3 +1,5 @@
+import { FcGoogle } from 'react-icons/fc';
+
 const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
 const SCOPE = process.env.NEXT_PUBLIC_GOOGLE_SCOPE;
 const REDIRECT_URI = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI;
@@ -8,9 +10,19 @@ const GoogleLoginButton = () => {
         window.location.assign(oauthUrl);
     };
     return (
-        <div className='bg-[blue] text-white flex w-16 justify-center b'>
-            <button onClick={handleGoogleLogin}>Google</button>
-        </div>
+        <>
+            <div
+                className='flex border-2 border-[#262626] border-black cursor-pointer h-16 rounded-xl overflow-hidden'
+                onClick={handleGoogleLogin}
+            >
+                <div className='flex bg-[#262626] basis-2/12 justify-center items-center text-2xl '>
+                    <FcGoogle />
+                </div>
+                <div className='flex text-black basis-10/12 justify-center items-center'>
+                    구글로 로그인하기
+                </div>
+            </div>
+        </>
     );
 };
 

--- a/src/components/button/GoogleLoginButton.tsx
+++ b/src/components/button/GoogleLoginButton.tsx
@@ -12,13 +12,13 @@ const GoogleLoginButton = () => {
     return (
         <>
             <div
-                className='flex border-2 border-[#262626] border-black cursor-pointer h-16 rounded-xl overflow-hidden'
+                className='flex border-2 border-dark-black border-black cursor-pointer h-16 rounded-xl overflow-hidden'
                 onClick={handleGoogleLogin}
             >
-                <div className='flex bg-[#262626] basis-2/12 justify-center items-center text-2xl '>
+                <div className='flex bg-dark-black basis-2/12 justify-center items-center text-2xl '>
                     <FcGoogle />
                 </div>
-                <div className='flex text-black basis-10/12 justify-center items-center'>
+                <div className='flex text-dark-black basis-10/12 justify-center items-center'>
                     구글로 로그인하기
                 </div>
             </div>

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -1,0 +1,18 @@
+import { kakaoInit } from '@/utils/kakao';
+
+const KakaoLoginButton = () => {
+    const kakaoLogin = async () => {
+        const kakao = kakaoInit();
+        kakao.Auth.authorize({
+            redirectUri: `${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}`
+        });
+    };
+
+    return (
+        <div>
+            <div onClick={kakaoLogin}>kakao</div>
+        </div>
+    );
+};
+
+export default KakaoLoginButton;

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -1,4 +1,4 @@
-import { kakaoInit } from '@/utils/kakao';
+import { kakaoInit } from '@/utils/oauth';
 
 const KakaoLoginButton = () => {
     const kakaoLogin = async () => {

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -18,7 +18,7 @@ const KakaoLoginButton = () => {
                 <div className='flex bg-kakao-color basis-2/12 justify-center items-center text-2xl'>
                     <RiKakaoTalkFill />
                 </div>
-                <div className='flex text-black basis-10/12 justify-center items-center'>
+                <div className='flex text-dark-black basis-10/12 justify-center items-center'>
                     카카오로 로그인하기
                 </div>
             </div>

--- a/src/components/button/KakaoLoginButton.tsx
+++ b/src/components/button/KakaoLoginButton.tsx
@@ -1,4 +1,5 @@
 import { kakaoInit } from '@/utils/oauth';
+import { RiKakaoTalkFill } from 'react-icons/ri';
 
 const KakaoLoginButton = () => {
     const kakaoLogin = async () => {
@@ -9,9 +10,19 @@ const KakaoLoginButton = () => {
     };
 
     return (
-        <div>
-            <div onClick={kakaoLogin}>kakao</div>
-        </div>
+        <>
+            <div
+                className='flex border-2 border-kakao-color border-black cursor-pointer h-16 rounded-xl'
+                onClick={kakaoLogin}
+            >
+                <div className='flex bg-kakao-color basis-2/12 justify-center items-center text-2xl'>
+                    <RiKakaoTalkFill />
+                </div>
+                <div className='flex text-black basis-10/12 justify-center items-center'>
+                    카카오로 로그인하기
+                </div>
+            </div>
+        </>
     );
 };
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Link from "next/link";
-import React, { useState } from "react";
+import Link from 'next/link';
+import React, { useState } from 'react';
+import LoginModal from '../modal/LoginModal';
 
 interface MenuProps {
     menu: string;
@@ -10,17 +11,19 @@ interface MenuProps {
     onClick: (index: number) => void;
 }
 
-export default function Header () {
+export default function Header() {
     // 로그인, 로그아웃 상태구현
     const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [isModal, setIsModal] = useState(false);
 
     const handleLogin = () => {
-        setIsLoggedIn(true);
+        setIsModal(true);
+        // setIsLoggedIn(true);
     };
 
     const handleLogout = () => {
         setIsLoggedIn(false);
-    }
+    };
 
     // 메뉴바 선택항목 상태구현
     const [menus, setMenus] = useState<[string, boolean][]>([
@@ -28,7 +31,7 @@ export default function Header () {
         ['일정관리', false],
         ['여행가방', false],
         ['커뮤니티', false],
-        ['이용안내', false],
+        ['이용안내', false]
     ]);
 
     const Menu = ({ menu, select, index, onClick }: MenuProps) => {
@@ -66,11 +69,15 @@ export default function Header () {
     return (
         <header className='x-0 top-0 z-50 left-0 w-full bg-white border-b border-gray-300'>
             <div className='container mx-auto my-0.5 h-24 flex justify-between flex-wrap p-5'>
-                <div className="flex space-x-16">
-                    <Link href='/' className="flex">
-                        <img className='w-120' src='/images/logo1.svg' alt="트리피 로고" />
+                <div className='flex space-x-16'>
+                    <Link href='/' className='flex'>
+                        <img
+                            className='w-120'
+                            src='/images/logo1.svg'
+                            alt='트리피 로고'
+                        />
                     </Link>
-                    <nav className="flex items-center space-x-8">
+                    <nav className='flex items-center space-x-8'>
                         {menus.map((menu, index) => (
                             <Menu
                                 key={`menu${index}`}
@@ -82,21 +89,30 @@ export default function Header () {
                         ))}
                     </nav>
                 </div>
-                <div className="flex items-center space-x-6">
+                <div className='flex items-center space-x-6'>
                     {isLoggedIn ? (
                         <>
                             <Link href='/mypage'>마이페이지</Link>
-                            <button onClick={handleLogout} className="focus:outline-none">
+                            <button
+                                onClick={handleLogout}
+                                className='focus:outline-none'
+                            >
                                 로그아웃
                             </button>
                             <Link href='/'>
-                                <img className='w-12 h-12' src='/images/user.svg' alt="프로필 사진" />
+                                <img
+                                    className='w-12 h-12'
+                                    src='/images/user.svg'
+                                    alt='프로필 사진'
+                                />
                             </Link>
                         </>
                     ) : (
                         <>
-                        
-                            <button onClick={handleLogin} className="focus:outline-none">
+                            <button
+                                onClick={handleLogin}
+                                className='focus:outline-none'
+                            >
                                 로그인
                             </button>
                             <Link href='/'>회원가입</Link>
@@ -104,6 +120,7 @@ export default function Header () {
                     )}
                 </div>
             </div>
+            {isModal && <LoginModal setIsModal={setIsModal} />}
         </header>
     );
 }

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import GoogleLoginButton from '../button/GoogleLoginButton';
+import KakaoLoginButton from '../button/KakaoLoginButton';
+import Modal from './Modal';
+
+const LoginModal = ({ setIsModal }: any) => {
+    return (
+        <Modal
+            modalMode={1}
+            title='로그인 하기'
+            setModalState={setIsModal}
+            onClickCompleteButton={() => setIsModal(false)}
+            completeText='X'
+        >
+            <div className='flex flex-col'>
+                <div className='flex flex-col gap-4 justify-center h-4/5 p-5'>
+                    <KakaoLoginButton />
+                    <GoogleLoginButton />
+                </div>
+                <div className='text-xs text-center text-grey mt-4 p-5'>
+                    소셜 로그인으로 가입 시&nbsp;
+                    <span className='text-kakao-color'>
+                        이용약관, 개인정보처리방침, 전자금융거래약관
+                    </span>
+                    에 동의함으로 처리됩니다.
+                </div>
+                <div className='flex justify-center items-center pt-4 h-1/6 border-t border-lightgrey cursor-pointer'>
+                    회원가입
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default LoginModal;

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -1,4 +1,0 @@
-export const getAuthCode = async () => {
-    const code = window.location.href.split('?')[1].split('&')[0].slice(5);
-    return code;
-};

--- a/src/utils/kakao.ts
+++ b/src/utils/kakao.ts
@@ -1,0 +1,7 @@
+export const kakaoInit = () => {
+    const kakao = (window as any).Kakao;
+    if (!kakao.isInitialized()) {
+        kakao.init(process.env.NEXT_PUBLIC_KAKAO_APP_KEY);
+    }
+    return kakao;
+};

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -1,3 +1,8 @@
+export const splitAuthCode = async () => {
+    const code = window.location.href.split('?')[1].split('&')[0].slice(5);
+    return code;
+};
+
 export const kakaoInit = () => {
     const kakao = (window as any).Kakao;
     if (!kakao.isInitialized()) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,8 @@ module.exports = {
                 brightgrey: '#F9F9F9',
                 lightgrey: '#E5E5E5',
                 grey: '#A3A3A3',
-                darkgrey: '#666666'
+                darkgrey: '#666666',
+                'kakao-color': '#FAE100'
             },
             width: {
                 'box-width': '412px'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,8 @@ module.exports = {
                 lightgrey: '#E5E5E5',
                 grey: '#A3A3A3',
                 darkgrey: '#666666',
-                'kakao-color': '#FAE100'
+                'kakao-color': '#FAE100',
+                'dark-black': '#262626'
             },
             width: {
                 'box-width': '412px'


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #31 - 카카오 소셜 로그인

📋 PR Checklist
[ ] 카카오 소셜 로그인
[ ] 버튼 및 모달 수정
[ ] 로그인 버튼 클릭 시 모달창 렌더링

📌 유의사항
카카오 로그인 인가코드 발급받았고, .env.local 파일 수정해서 노션에 올렸습니다 !
로그인 버튼에 로그인 모달창 연결해두었습니다
현재는 리다이렉트 페이지만 있어서 인가코드가 발급되는 지만 확인하였고 API 나오면 accessToken 발급 후 메인페이지(로그인시도페이지)로 라우팅하면 될 것 같습니다!

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브

모달창
<img width="1440" alt="모달창" src="https://github.com/UMC-TRIPY/web-front/assets/63959171/73e911eb-61ac-4a4b-8e73-f13d448ebde1">

구글 로그인 인가코드
<img width="492" alt="googleLogin" src="https://github.com/UMC-TRIPY/web-front/assets/63959171/dfa5489f-e200-4e81-9756-731a406f1aca">

카카오 로그인 인가코드
<img width="492" alt="kakaoLogin" src="https://github.com/UMC-TRIPY/web-front/assets/63959171/942dc7f1-c593-42de-acd5-e39eef1b16a6">


