### PR TITLE
[CHORE] #37 - 환율 API 재연동 및 일부 코드 수정

### DIFF
--- a/src/components/detailschedule/FriendList.tsx
+++ b/src/components/detailschedule/FriendList.tsx
@@ -16,6 +16,21 @@ export default function FriendList() {
     const onClick = (friend: string) => {
         alert(`${friend} 삭제 완료!`);
     };
+
+    const SharingFriend = ({ friend }: { friend: string }) => {
+        return (
+            <div className='text-xs h-8 rounded-xl bg-brightgrey py-1.5 px-2.5  mr-3 flex items-center'>
+                <span className='text-darkgrey mr-2.5'>{friend}</span>
+                <span
+                    className='text-darkgrey hover:cursor-pointer'
+                    onClick={() => onClick(friend)}
+                >
+                    X
+                </span>
+            </div>
+        );
+    };
+
     return (
         <div>
             <div className='py-5'>
@@ -25,24 +40,10 @@ export default function FriendList() {
                         <div className='flex items-center'>
                             {friends.map((friend, index) => {
                                 return (
-                                    <div
-                                        key={`frcon${index}`}
-                                        className='text-xs h-8 rounded-xl bg-brightgrey py-1.5 px-2.5  mr-3 flex items-center'
-                                    >
-                                        <span
-                                            key={`frname${index}`}
-                                            className='text-darkgrey mr-2.5'
-                                        >
-                                            {friend}
-                                        </span>
-                                        <span
-                                            key={`frdel${index}`}
-                                            className='text-darkgrey hover:cursor-pointer'
-                                            onClick={() => onClick(friend)}
-                                        >
-                                            X
-                                        </span>
-                                    </div>
+                                    <SharingFriend
+                                        friend={friend}
+                                        key={`sharing${index}`}
+                                    />
                                 );
                             })}
                             <div className='ml-1 h-7 w-7 bg-primary flex items-center justify-center rounded-full font-medium text-2xl hover:cursor-pointer'>
@@ -51,11 +52,6 @@ export default function FriendList() {
                         </div>
                     </div>
                     <div className='flex items-center'>
-                        <img
-                            className='h-[70px] hover:cursor-pointer'
-                            src='/images/helpbot.png'
-                            alt='none'
-                        />
                         <LiaExchangeAltSolid
                             className='hover:cursor-pointer mr-8 ml-7'
                             size={40}
@@ -63,6 +59,13 @@ export default function FriendList() {
                         <FiEdit className='hover:cursor-pointer' size={40} />
                     </div>
                 </div>
+            </div>
+            <div className='absolute bottom-[200px] flex justify-end w-[1380px]'>
+                <img
+                    className='fixed hover:cursor-pointer'
+                    src='/images/helpbot.png'
+                    alt='none'
+                />
             </div>
         </div>
     );

--- a/src/components/hotplace/HotPlace.tsx
+++ b/src/components/hotplace/HotPlace.tsx
@@ -2,7 +2,7 @@ import { Loader } from '@googlemaps/js-api-loader';
 
 export default function HotPlace() {
     // 환경변수에서 Map Key 가져옴
-    const mapKey: any = process.env.NEXT_PUBLIC_MAP_KEY;
+    const mapKey: any = process.env.NEXT_PUBLIC_GOOGLE_MAP_KEY;
     const apiOptions: any = {
         apiKey: mapKey
     };

--- a/src/components/infocity/Calendar.tsx
+++ b/src/components/infocity/Calendar.tsx
@@ -1,0 +1,94 @@
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { useEffect } from 'react';
+import { ko } from 'date-fns/locale';
+
+interface Props {
+    claName: string;
+    startDate: Date | null;
+    endDate: Date | null;
+    isOpen: boolean;
+    setStartDate: React.Dispatch<React.SetStateAction<Date | null>>;
+    setEndDate: React.Dispatch<React.SetStateAction<Date | null>>;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function Calendar({
+    claName,
+    startDate,
+    endDate,
+    isOpen,
+    setStartDate,
+    setEndDate,
+    setIsOpen
+}: Props) {
+    const activeColor = () => {
+        let outsideMonth: any = document.getElementsByClassName(
+            'react-datepicker__day--outside-month'
+        );
+        Object.values(outsideMonth).map((day: any) => {
+            day.style.color = '#A3A3A3';
+        });
+    };
+    const onChange = (dates: any) => {
+        const [start, end] = dates;
+        setStartDate(start);
+        setEndDate(end);
+    };
+    useEffect(() => {
+        endDate === null ? setIsOpen(isOpen) : setIsOpen(!isOpen);
+    }, [endDate]);
+    useEffect(() => {
+        activeColor();
+    }, []);
+    return (
+        <>
+            <div className={claName}>
+                <DatePicker
+                    dateFormatCalendar='yyyy년 MM월'
+                    selected={startDate}
+                    onChange={onChange}
+                    startDate={startDate}
+                    endDate={endDate}
+                    selectsRange
+                    inline
+                    locale={ko}
+                    onMonthChange={activeColor}
+                    renderCustomHeader={({
+                        date,
+                        decreaseMonth,
+                        increaseMonth,
+                        prevMonthButtonDisabled,
+                        nextMonthButtonDisabled
+                    }: any) => (
+                        <div className='flex justify-between px-5 py-3 text-base'>
+                            <div className='font-bold'>
+                                {date.getFullYear()}년 {date.getMonth() + 1}월
+                            </div>
+                            <div>
+                                <button
+                                    type='button'
+                                    onClick={decreaseMonth}
+                                    disabled={prevMonthButtonDisabled}
+                                >
+                                    <img
+                                        className='rotate-180'
+                                        src='/images/calendararrow.png'
+                                    />
+                                </button>
+                                <button
+                                    type='button'
+                                    onClick={increaseMonth}
+                                    className='ml-6'
+                                    disabled={nextMonthButtonDisabled}
+                                >
+                                    <img src='/images/calendararrow.png' />
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                />
+            </div>
+        </>
+    );
+}

--- a/src/components/infocity/ExchangeRate.tsx
+++ b/src/components/infocity/ExchangeRate.tsx
@@ -3,22 +3,25 @@ import { LiaExchangeAltSolid } from 'react-icons/lia';
 import axios from 'axios';
 
 export default function ExchangeRate() {
+    const currencyKey = process.env.NEXT_PUBLIC_EXCHANGE_KEY;
     const [cur, setCur] = useState<number>(0);
     // 환율 대한민국 고정할거면 원화 자리에 krw 고정
     // 나라 정보와 환율도 가져와야함 => 백엔드에서 페이지 접속할 때 넘겨줘야함
     // 환율 가져오면 그에 따른 뒷자리도 가져와야함 => 배열로 만들어두기?
     useEffect(() => {
         axios
-            .get(
-                // ~~/currencies/{원화}/{환전하고 싶은 통화}.json
-                'https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/krw.json'
-            )
+            .get(`http://data.fixer.io/api/latest?access_key=${currencyKey}`)
             .then((res) => {
-                setCur(res.data.krw.jpy);
-                console.log(`환율 정보 : ${res.data.krw.jpy}`);
+                // base가 EUR 이기 떄문에 원화와 바꾸고자하는 환율을 가져와서 계산해주어야함
+                // API는 일 100회 제한
+                let won = res.data.rates.KRW;
+                let other = res.data.rates.JPY;
+                setCur(other / won);
+                console.log('환율 정보 : ' + other / won);
             })
             .catch((err) => console.log(err));
     }, []);
+
     const [before, setBefore] = useState<string>('');
     const [after, setAfter] = useState<string>(before);
     const [isWon, setIsWon] = useState<boolean>(true);

--- a/src/components/infocity/InfoCity.tsx
+++ b/src/components/infocity/InfoCity.tsx
@@ -1,31 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { IoThunderstormOutline } from 'react-icons/io5';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import InfoWeather from './InfoWeather';
 import ExchangeRate from './ExchangeRate';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
-import { ko } from 'date-fns/locale';
 import format from 'date-fns/format';
+import Calendar from './Calendar';
 
 export default function InfoCity() {
-    const [startDate, setStartDate] = useState<null | Date>(null);
-    const [endDate, setEndDate] = useState<null | Date>(null);
+    const [startDate, setStartDate] = useState<Date | null>(null);
+    const [endDate, setEndDate] = useState<Date | null>(null);
     const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [isUser, setIsUser] = useState<boolean>(false);
     const temperatures = [
         ['16º', '1º', '1~3월'],
         ['16º', '1º', '4~6월'],
         ['16º', '1º', '7~9월'],
         ['16º', '1º', '10~12월']
     ];
-    const activeColor = () => {
-        let outsideMonth: any = document.getElementsByClassName(
-            'react-datepicker__day--outside-month'
-        );
-        Object.values(outsideMonth).map((day: any) => {
-            day.style.color = '#A3A3A3';
-        });
-    };
     const SelectDates = ({
         title,
         value
@@ -39,25 +30,13 @@ export default function InfoCity() {
                     e.preventDefault();
                     setIsOpen(!isOpen);
                 }}
-                className='flex items-center justify-between px-5 h-16 w-80 text-grey border border-lightgrey rounded-l hover:cursor-pointer'
+                className='flex items-center justify-between px-5 h-16 w-5/12 text-grey border border-lightgrey rounded-l hover:cursor-pointer'
             >
                 {value === null ? title : format(value, 'yyyy-MM-dd')}
                 <AiOutlineCalendar size={24} />
             </div>
         );
     };
-    const onChange = (dates: any) => {
-        const [start, end] = dates;
-        setStartDate(start);
-        setEndDate(end);
-    };
-    useEffect(() => {
-        endDate === null ? setIsOpen(isOpen) : setIsOpen(!isOpen);
-    }, [endDate]);
-    useEffect(() => {
-        activeColor();
-    }, []);
-    const date = new Date();
     return (
         <div className='flex justify-between mt-32'>
             <img src='/images/location.png' alt='none' />
@@ -84,7 +63,18 @@ export default function InfoCity() {
                 </div>
                 {/* 환율 계산 부분 */}
                 <div className=''>
-                    <span className='text-2xl'>환율 계산기</span>
+                    <div className='flex text-xs items-center'>
+                        <span className='text-2xl mr-4'>환율 계산기</span>
+                        <button
+                            className={
+                                isUser
+                                    ? 'bg-lightgrey py-1 px-3 rounded-2xl text-darkgrey'
+                                    : 'hidden'
+                            }
+                        >
+                            환율정보 저장하기
+                        </button>
+                    </div>
                     <ExchangeRate />
                 </div>
                 {/* 날짜 선택 부분 */}
@@ -95,65 +85,31 @@ export default function InfoCity() {
                         <SelectDates title='도착일' value={endDate} />
                         <button
                             type='button'
-                            className='w-auto  bg-black text-white rounded-r px-4'
+                            onClick={() => setIsUser(!isUser)}
+                            className={
+                                isUser
+                                    ? 'w-2/12  bg-primary rounded-r px-4'
+                                    : 'w-2/12  bg-black text-white rounded-r px-4'
+                            }
                         >
-                            로그인하기
+                            {isUser ? '등록하기' : '로그인하기'}
                         </button>
                     </div>
                 </div>
-                <div
-                    className={
+                {/* Calendar 사용시 아래 7개 props 필수 */}
+                <Calendar
+                    startDate={startDate}
+                    endDate={endDate}
+                    isOpen={isOpen}
+                    setStartDate={setStartDate}
+                    setEndDate={setEndDate}
+                    setIsOpen={setIsOpen}
+                    claName={
                         isOpen
                             ? 'block absolute mt-[522px] ml-[80px] z-10'
                             : 'hidden'
                     }
-                >
-                    <DatePicker
-                        dateFormatCalendar='yyyy년 MM월'
-                        selected={startDate}
-                        onChange={onChange}
-                        startDate={startDate}
-                        endDate={endDate}
-                        selectsRange
-                        inline
-                        locale={ko}
-                        onMonthChange={activeColor}
-                        renderCustomHeader={({
-                            date,
-                            decreaseMonth,
-                            increaseMonth,
-                            prevMonthButtonDisabled,
-                            nextMonthButtonDisabled
-                        }: any) => (
-                            <div className='flex justify-between px-5 py-3 text-base'>
-                                <div className='font-bold'>
-                                    {date.getFullYear()}년 {date.getMonth() + 1}
-                                    월
-                                </div>
-                                <div>
-                                    <button
-                                        type='button'
-                                        onClick={decreaseMonth}
-                                        disabled={prevMonthButtonDisabled}
-                                    >
-                                        <img
-                                            className='rotate-180'
-                                            src='/images/calendararrow.png'
-                                        />
-                                    </button>
-                                    <button
-                                        type='button'
-                                        onClick={increaseMonth}
-                                        className='ml-6'
-                                        disabled={nextMonthButtonDisabled}
-                                    >
-                                        <img src='/images/calendararrow.png' />
-                                    </button>
-                                </div>
-                            </div>
-                        )}
-                    />
-                </div>
+                />
             </div>
         </div>
     );


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #1 - 마이페이지 기능 구현
<img width="1440" alt="스크린샷 2023-07-19 오후 10 45 45" src="https://github.com/UMC-TRIPY/web-front/assets/114225974/9c4ab330-0c74-48d9-a0af-ff3a27527e08">
<img width="1440" alt="스크린샷 2023-07-19 오후 10 46 00" src="https://github.com/UMC-TRIPY/web-front/assets/114225974/8b1e1b5e-2d8c-4423-bffb-59f1c1ef7c29">

📋 PR Checklist
- [x] info 페이지 로그인하기 누를 시 등록하기로 변경 및 저장하기 버튼 생성 확인
- [x] 키 값 재설정 후 환율 정보, 구글맵 잘 동작하나 확인
- [x] 캘린더 작동 잘 하나 확인
- [x] schedule 페이지 우측 하단 챗봇 아이콘 고정되어 스크롤 해도 위치 그대로인지 확인

📌 유의사항
- 환율 정보 API 하루 요청 횟수가 100번이라 새로고침 많이하면 안 될 것 같습니다!

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
