### PR TITLE
[FEAT] 일정 상세보기 모달창

### DIFF
--- a/src/components/detailschedule/DetailSchedule.tsx
+++ b/src/components/detailschedule/DetailSchedule.tsx
@@ -13,7 +13,7 @@ export default function DetailSchedule() {
             {/* 친구 목록 */}
             <FriendList />
             {/* 여행 일정 */}
-            <LabelSchedules />
+            <LabelSchedules status='page' />
         </div>
     );
 }

--- a/src/components/detailschedule/FriendList.tsx
+++ b/src/components/detailschedule/FriendList.tsx
@@ -33,7 +33,7 @@ export default function FriendList() {
 
     return (
         <div>
-            <div className='py-5'>
+            <div className='py-5 mb-10'>
                 <div className='flex justify-between items-center'>
                     <div>
                         <div className='pb-2'>일정 공유 중인 친구</div>

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -148,7 +148,7 @@ export default function LabelSchedules() {
         <div className='text-xl mb-16'>
             {schedules.map((schedule, index) => {
                 return (
-                    <>
+                    <div key={index} className='mb-8'>
                         <div key={`schcon${index}`} className='mb-3'>
                             <span key={`schdaynum${index}`} className='mr-8 '>
                                 {index + 1}일차
@@ -198,7 +198,7 @@ export default function LabelSchedules() {
                                 </div>
                             );
                         })}
-                    </>
+                    </div>
                 );
             })}
         </div>

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -149,7 +149,7 @@ export default function LabelSchedules() {
             {schedules.map((schedule, index) => {
                 return (
                     <>
-                        <div key={`schcon${index}`} className='mb-3 mt-10'>
+                        <div key={`schcon${index}`} className='mb-3'>
                             <span key={`schdaynum${index}`} className='mr-8 '>
                                 {index + 1}일차
                             </span>

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -1,6 +1,10 @@
 import { CiLocationOn } from 'react-icons/ci';
 
-export default function LabelSchedules() {
+interface ILabelScheduleProps {
+    status: 'page' | 'modal';
+}
+
+export default function LabelSchedules({ status }: ILabelScheduleProps) {
     const schedules = [
         {
             date: '6월30일(토)',
@@ -145,62 +149,100 @@ export default function LabelSchedules() {
         }
     ];
     return (
-        <div className='text-xl mb-16'>
-            {schedules.map((schedule, index) => {
-                return (
-                    <div key={index} className='mb-8'>
-                        <div key={`schcon${index}`} className='mb-3'>
-                            <span key={`schdaynum${index}`} className='mr-8 '>
-                                {index + 1}일차
-                            </span>
-                            <span key={`schdate${index}`}>{schedule.date}</span>
-                        </div>
-                        {schedule.todos.map((todo, idx) => {
-                            return (
-                                <div
-                                    key={`schwrap${idx}`}
-                                    className={`border border-lightgrey border-l-8 rounded-lg pl-9 mb-2 ${todo.color}`}
-                                >
-                                    <div
-                                        key={`schtime${idx}`}
-                                        className='text-xs text-grey py-2.5'
+        <>
+            {status === 'page' ? (
+                <div className='text-xl mb-16'>
+                    {schedules.map((schedule, index) => {
+                        return (
+                            <div key={index} className='mb-8'>
+                                <div key={`schcon${index}`} className='mb-3'>
+                                    <span
+                                        key={`schdaynum${index}`}
+                                        className='mr-8 '
                                     >
-                                        {todo.time}
-                                    </div>
-                                    <div
-                                        key={`schcontent${idx}`}
-                                        className='flex justify-between text-base'
-                                    >
+                                        {index + 1}일차
+                                    </span>
+                                    <span key={`schdate${index}`}>
+                                        {schedule.date}
+                                    </span>
+                                </div>
+                                {schedule.todos.map((todo, idx) => {
+                                    return (
                                         <div
-                                            key={`schinwrap${idx}`}
-                                            className='flex'
+                                            key={`schwrap${idx}`}
+                                            className={`border border-lightgrey border-l-8 rounded-lg pl-9 mb-2 ${todo.color}`}
                                         >
                                             <div
-                                                key={`schdetail${idx}`}
-                                                className='mr-10 mb-4'
+                                                key={`schtime${idx}`}
+                                                className='text-xs text-grey py-2.5'
                                             >
-                                                {todo.content}
+                                                {todo.time}
                                             </div>
                                             <div
-                                                key={`schadd${idx}`}
-                                                className='text-grey'
+                                                key={`schcontent${idx}`}
+                                                className='flex justify-between text-base'
                                             >
+                                                <div
+                                                    key={`schinwrap${idx}`}
+                                                    className='flex'
+                                                >
+                                                    <div
+                                                        key={`schdetail${idx}`}
+                                                        className='mr-10 mb-4'
+                                                    >
+                                                        {todo.content}
+                                                    </div>
+                                                    <div
+                                                        key={`schadd${idx}`}
+                                                        className='text-grey'
+                                                    >
+                                                        {todo.additional}
+                                                    </div>
+                                                </div>
+                                                <div className='flex text-base items-center'>
+                                                    <CiLocationOn size={20} />
+                                                    <span className='ml-2 mr-4'>
+                                                        {todo.place}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : (
+                <div>
+                    {schedules.map((schedule, index) => (
+                        <div className='mb-4' key={index}>
+                            <div className='flex gap-4 text-grey mb-2'>
+                                <span>{index + 1}일차</span>
+                                <span>{schedule.date}</span>
+                            </div>
+                            {schedule.todos.map((todo, idx) => (
+                                <div
+                                    key={idx}
+                                    className={`border border-lightgrey border-l-8 rounded-lg pl-9 mb-2 ${todo.color}`}
+                                >
+                                    <div className='text-xs text-grey py-2.5'>
+                                        {todo.time}
+                                    </div>
+                                    <div className='flex justify-between'>
+                                        <div className='flex flex-col gap-2'>
+                                            <div>{todo.content}</div>
+                                            <div className='text-grey'>
                                                 {todo.additional}
                                             </div>
                                         </div>
-                                        <div className='flex text-base items-center'>
-                                            <CiLocationOn size={20} />
-                                            <span className='ml-2 mr-4'>
-                                                {todo.place}
-                                            </span>
-                                        </div>
                                     </div>
                                 </div>
-                            );
-                        })}
-                    </div>
-                );
-            })}
-        </div>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </>
     );
 }

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -224,13 +224,13 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                             {schedule.todos.map((todo, idx) => (
                                 <div
                                     key={idx}
-                                    className={`border border-lightgrey border-l-8 rounded-lg pl-9 mb-2 ${todo.color}`}
+                                    className={`border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${todo.color}`}
                                 >
-                                    <div className='text-xs text-grey py-2.5'>
+                                    <div className='text-xs text-grey pb-2'>
                                         {todo.time}
                                     </div>
                                     <div className='flex justify-between'>
-                                        <div className='flex flex-col gap-2'>
+                                        <div className='flex flex-col'>
                                             <div>{todo.content}</div>
                                             <div className='text-grey'>
                                                 {todo.additional}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import LoginModal from '../modal/LoginModal';
 import ScheduleAddModal from '../modal/ScheduleAddModal';
 import ScheduleDeleteModal from '../modal/ScheduleDeleteModal';
+import ScheduleDetailModal from '../modal/ScheduleDetailModal';
 
 interface MenuProps {
     menu: string;
@@ -24,9 +25,13 @@ export default function Header() {
     // 일정 삭제 모달 테스트용. 스케줄 페이지로 이동 필요.
     const [isScheduleDeleteModal, setIsScheduleDeleteModal] = useState(false);
 
+    // 일정 상세보기 모달 테스트용. 일정 등록 페이지로 이동 필요.
+    const [isScheduleDetailModal, setIsScheduleDetailModal] = useState(false);
+
     const addSchedule = () => {
         // setIsScheduleAddModal(true);
-        setIsScheduleDeleteModal(true);
+        // setIsScheduleDeleteModal(true);
+        setIsScheduleDetailModal(true);
     };
 
     const handleLogin = () => {
@@ -139,8 +144,11 @@ export default function Header() {
             {/* {isScheduleAddModal && (
                 <ScheduleAddModal setIsModal={setIsScheduleAddModal} />
             )} */}
-            {isScheduleDeleteModal && (
+            {/* {isScheduleDeleteModal && (
                 <ScheduleDeleteModal setIsModal={setIsScheduleDeleteModal} />
+            )} */}
+            {isScheduleDetailModal && (
+                <ScheduleDetailModal setIsModal={setIsScheduleDetailModal} />
             )}
         </header>
     );

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -12,7 +12,7 @@ const ScheduleDetailModal = ({ setIsModal }: any) => {
             completeText=''
         >
             <div className='h-96 overflow-scroll pl-8 pr-8'>
-                <LabelSchedules />
+                <LabelSchedules status='modal' />
             </div>
         </Modal>
     );

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -11,7 +11,7 @@ const ScheduleDetailModal = ({ setIsModal }: any) => {
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''
         >
-            <div className='h-96 overflow-scroll p-8'>
+            <div className='h-96 overflow-scroll pl-8 pr-8'>
                 <LabelSchedules />
             </div>
         </Modal>

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -11,7 +11,7 @@ const ScheduleDetailModal = ({ setIsModal }: any) => {
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''
         >
-            <div className='h-96 overflow-scroll pl-8 pr-8'>
+            <div className='h-96 overflow-scroll pl-8 pr-8 bg-gradient-to-b from-neutral-50 from-90% to-main-color'>
                 <LabelSchedules status='modal' />
             </div>
         </Modal>

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -11,7 +11,7 @@ const ScheduleDetailModal = ({ setIsModal }: any) => {
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''
         >
-            <div className='h-96 overflow-scroll pl-8 pr-8 bg-gradient-to-b from-neutral-50 from-90% to-main-color'>
+            <div className='h-96 overflow-scroll pl-8 pr-8 bg-gradient-to-t from-blur to-white to-30%'>
                 <LabelSchedules status='modal' />
             </div>
         </Modal>

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import LabelSchedules from '../detailschedule/LabelSchedules';
+import Modal from './Modal';
+
+const ScheduleDetailModal = ({ setIsModal }: any) => {
+    return (
+        <Modal
+            modalMode={0}
+            title='일정 상세보기'
+            setModalState={setIsModal}
+            onClickCompleteButton={() => setIsModal(false)}
+            completeText=''
+        >
+            <div className='h-96 overflow-scroll p-8'>
+                <LabelSchedules />
+            </div>
+        </Modal>
+    );
+};
+
+export default ScheduleDetailModal;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,10 +23,11 @@ module.exports = {
                 grey: '#A3A3A3',
                 darkgrey: '#666666',
                 'kakao-color': '#FAE100',
-                'dark-black': '#262626'
+                'dark-black': '#262626',
+                blur: 'rgba(232, 232, 232, 1)'
             },
             width: {
-                'box-width': '412px',
+                'box-width': '412px'
             },
             height: {
                 'box-height': '424px',


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #45 - 일정 상세보기 모달창

📋 PR Checklist
[ ] 일정 상세보기 모달창 구현
[ ]

📌 유의사항
기존 LabelSchedules 컴포넌트를 'page'와 'modal' 일 때 다르게 처리하도록 status 값 추가하였습니다 !
피그마마처럼 하얗게 블러처리가 잘 안되서 일단 tripy 색으로 했는데 할 줄 아시는 분 수정 부탁드려요ㅠㅠ
<img width="587" alt="image" src="https://github.com/UMC-TRIPY/web-front/assets/63959171/a9d457d0-33aa-46c1-8155-1f687ff6f06c">

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
<img width="1440" alt="상세보기" src="https://github.com/UMC-TRIPY/web-front/assets/63959171/36d3bd8c-8679-429b-8e52-6fb998daa3cc">