### PR TITLE
[FEAT] 모달창 켜져있을 때 스크롤 막기

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Portal from '@/components/modal/Portal';
 import { IoCloseOutline } from 'react-icons/io5';
 
@@ -66,6 +66,17 @@ export default function Modal({
             <div className='basis-[85%]'>{children}</div>
         </>
     ];
+
+    useEffect(() => {
+        /* TODO: 스크롤이 내려가 있는 상태로 모달창 띄우는 방법도 고려 */
+        window.scrollTo(0, 0);
+        // const portal = document.getElementById('portal');
+        // if (portal) portal.classList.add(`top-[${window.scrollY}px]`);
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.body.style.overflow = 'unset';
+        };
+    }, []);
 
     return (
         <Portal selector='#body'>


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #50 - 모달창 켜져있을 때 스크롤 막기

📋 PR Checklist
[ ] 모달창 켜져있을 때 스크롤 막기

📌 유의사항
스크롤이 내려간 상태로 스크롤 막으려면 추가 코드 필요

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
