### PR TITLE
[FEAT] 여행계획 메인페이지 검색 모달창

### DIFF
--- a/src/components/modal/SearchboxModal.tsx
+++ b/src/components/modal/SearchboxModal.tsx
@@ -1,17 +1,37 @@
-// SearchboxModal.tsx
-import React, { useState } from 'react';
+import React from 'react';
 import TransparentModal from './TransparentModal';
 import { BiSearch } from 'react-icons/bi';
 import { RxCross1 } from 'react-icons/rx';
-import DetailBox from '../schedulemain/detailBox';
-import HotSearch from '../schedulemain/hotSearch';
 
 interface CityProps {
+    city: string;
+    onClick: () => void;
+}
+
+function City({ city, onClick }: CityProps) {
+    return (
+        <div className="border border-grey rounded-full mr-2">
+            <div className="flex px-3 py-2 text-[12px]">
+                {city}
+                <button
+                    className="pl-2 pb-0.5" // RxCross가 중앙에 위치하기 위해 pb-0.5
+                    onClick={onClick}
+                >
+                    <RxCross1 size={12} />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+interface SearchboxModalProps {
+    setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
+    onCreateSchedule: () => void;
     selectedCities: string[];
     setSelectedCities: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-function City({ selectedCities, setSelectedCities }: CityProps) {
+function SearchboxModal({ setIsModal, selectedCities, setSelectedCities, onCreateSchedule }: SearchboxModalProps) {
     const refCities = [ // 자동완성 검색어
         { id: 1, place: '바르셀로나' },
         { id: 2, place: '브라질' },
@@ -21,135 +41,105 @@ function City({ selectedCities, setSelectedCities }: CityProps) {
         { id: 6, place: '브루클린' },
         { id: 7, place: '벨기에' },
     ];
-    const [isCreatingSchedule, setIsCreatingSchedule] = useState<boolean>(false);
-    const onClick = (refCity: string) => {
-        if (!selectedCities.includes(refCity)) { // 이미 선택된 도시가 아니면
+
+    const onClickCity = (refCity: string) => {
+        if (!selectedCities.includes(refCity)) {  // 이미 선택된 도시가 아니면
             setSelectedCities(prevCities => [...prevCities, refCity]); // 배열에 삽입
         }
     };
-    const onRemoveCity = (city: string) => { // 선택된 도시 삭제
+
+    const onClickRemoveCity = (city: string) => { // 선택된 도시 삭제
         setSelectedCities(prevCities => prevCities.filter(item => item !== city));
     };
-    const onCreateSchedule = () => { // 선택된 도시로 일정 생성
-        console.log('선택된 도시들:', selectedCities);
-        setIsCreatingSchedule(true);
-    };
 
+    const onClickCreateSchedule = () => { // 선택된 도시로 일정 생성
+        if (selectedCities.length > 0) {
+            console.log('선택된 도시들:', selectedCities);
+            onCreateSchedule();
+            setIsModal(false);
+            setSelectedCities(selectedCities);
+        }
+    };
     if (selectedCities.length > 0) { // 도시를 선택한 경우
         return (
-            <div>
-                <div className='flex'>
-                    {selectedCities.map((city, index) => (
-                        <div className='flex text-center px-3 py-2 mr-2 rounded-full border border-grey text-[12px] text-darkgrey' key={index}>
-                            {city}
-                            <button 
-                                className='pl-2 pb-0.5' // RxCross가 중앙에 위치하기 위해 pb-0.5
-                                onClick={() => onRemoveCity(city)}
+            <TransparentModal
+                modalMode={1}
+                title=''
+                setModalState={setIsModal}
+                onClickCompleteButton={() => setIsModal(false)}
+                completeText=''
+            >
+                <div className='px-[30px] pt-2'>
+                    <div className='border-b border-grey'></div>
+                    <div className='p-3.5'>
+                        <div className="flex">
+                            {selectedCities.map((city, index) => (
+                                <City
+                                    key={index}
+                                    city={city}
+                                    onClick={() => onClickRemoveCity(city)}
+                                />
+                            ))}
+                            <button
+                                className='px-3 py-2 rounded-full bg-primary text-[12px]'
+                                onClick={onClickCreateSchedule}
                             >
-                                <RxCross1 size={12}/>
+                                일정 생성
                             </button>
                         </div>
-                    ))}
-                    <button 
-                        className='px-3 py-2 rounded-full bg-primary text-[12px]'
-                        onClick={onCreateSchedule} // 배열에 담긴 도시들을 모달창 밖에 출력하고싶어요
-                        >
-                        일정 생성
-                    </button>
-                </div>
-                <div>
-                    {refCities.map((refCity, index) => {
-                        return (
+                        {refCities.map((refCity, index) => (
                             <div className="border-b border-lightgrey py-[14px]" key={index}>
                                 <div className='flex justify-between items-center'>
                                     <div className='flex'>
                                         <BiSearch size={24} className='mr-3' />
                                         {refCity.place}
                                     </div>
-                                    <button 
+                                    <button
                                         className='px-4 py-2 rounded-full bg-lightgrey text-[12px]'
-                                        onClick={() => onClick(refCity.place)}>
+                                        onClick={() => onClickCity(refCity.place)}
+                                    >
                                         선택
                                     </button>
                                 </div>
                             </div>
-                        )
-                    })}
-                </div>
-            </div>
-        );
-    } 
-    return ( // 도시 선택 안한 최초 검색창
-        <div>
-            {refCities.map((refCity, index) => {
-                return (
-                    <div className="border-b border-lightgrey py-[14px]" key={index}>
-                        <div className='flex justify-between items-center'>
-                            <div className='flex'>
-                                <BiSearch size={24} className='mr-3' />
-                                {refCity.place}
-                            </div>
-                            <button 
-                                className='px-4 py-2 rounded-full bg-lightgrey'
-                                onClick={() => onClick(refCity.place)}>
-                                <div className='text-[12px]'>선택</div>
-                            </button>
-                        </div>
+                        ))}
                     </div>
-                )
-            })}
-        </div>
-    )
-}
-
-function SearchboxModal ({ setIsModal }: any) {
-    const [selectedCities, setSelectedCities] = useState<string[]>([]);
-    const [isCreatingSchedule, setIsCreatingSchedule] = useState<boolean>(false);
-
-    const handleCreateSchedule = () => {
-        setIsCreatingSchedule(true);
-    };
-    
-    return (
-        <TransparentModal
-            modalMode={1}
-            title=''
-            setModalState={setIsModal}
-            onClickCompleteButton={() => setIsModal(false)}
-            completeText=''
-        >
-            <div className='px-[30px] pt-2'>
-                <div className='border-b border-grey'></div>
-                <div className='p-3.5'>
-                    <City
-                        selectedCities={selectedCities} // City 컴포넌트에 선택된 도시들을 props로 전달
-                        setSelectedCities={setSelectedCities} // City 컴포넌트에서 선택된 도시들을 수정하는 함수를 props로 전달
-                    />
                 </div>
-            </div>
-             {/* 일정 생성 버튼 */}
-      <div className="flex justify-center mt-4">
-        {!isCreatingSchedule ? (
-          <button
-            className="px-3 py-2 rounded-full bg-primary text-[12px]"
-            onClick={handleCreateSchedule}
-          >
-            일정 생성
-          </button>
-        ) : (
-          <div className="mt-4 p-3 border border-grey rounded">
-            <p>선택된 도시들:</p>
-            <ul>
-              {selectedCities.map((city, index) => (
-                <li key={index}>{city}</li>
-              ))}
-            </ul>
-            
-          </div>
-        )}
-      </div>
-        </TransparentModal>
-    );
-};
+            </TransparentModal>
+        );
+    }
+    return ( // 도시 선택 안한 최초 검색창
+        <TransparentModal
+                modalMode={1}
+                title=''
+                setModalState={setIsModal}
+                onClickCompleteButton={() => setIsModal(false)}
+                completeText=''
+            >
+                <div className='px-[30px] pt-2'>
+                    <div className='border-b border-grey'></div>
+                    <div className='p-3.5'>
+                        {refCities.map((refCity, index) => (
+                            <div className="border-b border-lightgrey py-[14px]" key={index}>
+                                <div className='flex justify-between items-center'>
+                                    <div className='flex'>
+                                        <BiSearch size={24} className='mr-3' />
+                                        {refCity.place}
+                                    </div>
+                                    <button
+                                        className='px-4 py-2 rounded-full bg-lightgrey text-[12px]'
+                                        onClick={() => onClickCity(refCity.place)}
+                                    >
+                                        선택
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </TransparentModal>
+    )
+    
+}
 
 export default SearchboxModal;

--- a/src/components/modal/SearchboxModal.tsx
+++ b/src/components/modal/SearchboxModal.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Modal from './Modal';
+
+const SearchboxModal = ({ setIsModal }: any) => {
+    return (
+        <Modal
+            modalMode={0}
+            title='일정 상세보기'
+            setModalState={setIsModal}
+            onClickCompleteButton={() => setIsModal(false)}
+            completeText=''
+        >
+            <div className='flex flex-col-reverse'>
+                <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
+                <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default SearchboxModal;

--- a/src/components/modal/SearchboxModal.tsx
+++ b/src/components/modal/SearchboxModal.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import TransparentModal from './TransparentModal';
 import { BiSearch } from 'react-icons/bi';
 import { RxCross1 } from 'react-icons/rx';
+import DetailBox from '../schedulemain/detailBox';
+import HotSearch from '../schedulemain/hotSearch';
 
 interface CityProps {
     selectedCities: string[];
@@ -19,7 +21,7 @@ function City({ selectedCities, setSelectedCities }: CityProps) {
         { id: 6, place: '브루클린' },
         { id: 7, place: '벨기에' },
     ];
-    
+    const [isCreatingSchedule, setIsCreatingSchedule] = useState<boolean>(false);
     const onClick = (refCity: string) => {
         if (!selectedCities.includes(refCity)) { // 이미 선택된 도시가 아니면
             setSelectedCities(prevCities => [...prevCities, refCity]); // 배열에 삽입
@@ -27,6 +29,10 @@ function City({ selectedCities, setSelectedCities }: CityProps) {
     };
     const onRemoveCity = (city: string) => { // 선택된 도시 삭제
         setSelectedCities(prevCities => prevCities.filter(item => item !== city));
+    };
+    const onCreateSchedule = () => { // 선택된 도시로 일정 생성
+        console.log('선택된 도시들:', selectedCities);
+        setIsCreatingSchedule(true);
     };
 
     if (selectedCities.length > 0) { // 도시를 선택한 경우
@@ -44,7 +50,10 @@ function City({ selectedCities, setSelectedCities }: CityProps) {
                             </button>
                         </div>
                     ))}
-                    <button className='px-3 py-2 rounded-full bg-primary text-[12px]'>
+                    <button 
+                        className='px-3 py-2 rounded-full bg-primary text-[12px]'
+                        onClick={onCreateSchedule} // 배열에 담긴 도시들을 모달창 밖에 출력하고싶어요
+                        >
                         일정 생성
                     </button>
                 </div>
@@ -95,6 +104,12 @@ function City({ selectedCities, setSelectedCities }: CityProps) {
 
 function SearchboxModal ({ setIsModal }: any) {
     const [selectedCities, setSelectedCities] = useState<string[]>([]);
+    const [isCreatingSchedule, setIsCreatingSchedule] = useState<boolean>(false);
+
+    const handleCreateSchedule = () => {
+        setIsCreatingSchedule(true);
+    };
+    
     return (
         <TransparentModal
             modalMode={1}
@@ -112,6 +127,27 @@ function SearchboxModal ({ setIsModal }: any) {
                     />
                 </div>
             </div>
+             {/* 일정 생성 버튼 */}
+      <div className="flex justify-center mt-4">
+        {!isCreatingSchedule ? (
+          <button
+            className="px-3 py-2 rounded-full bg-primary text-[12px]"
+            onClick={handleCreateSchedule}
+          >
+            일정 생성
+          </button>
+        ) : (
+          <div className="mt-4 p-3 border border-grey rounded">
+            <p>선택된 도시들:</p>
+            <ul>
+              {selectedCities.map((city, index) => (
+                <li key={index}>{city}</li>
+              ))}
+            </ul>
+            
+          </div>
+        )}
+      </div>
         </TransparentModal>
     );
 };

--- a/src/components/modal/SearchboxModal.tsx
+++ b/src/components/modal/SearchboxModal.tsx
@@ -1,21 +1,61 @@
+// SearchboxModal.tsx
 import React from 'react';
-import Modal from './Modal';
+import TransparentModal from './TransparentModal';
+import { BiSearch } from 'react-icons/bi';
 
-const SearchboxModal = ({ setIsModal }: any) => {
+function City() {
+    const refCities = [ // 자동완성 검색어
+        { id: 1, place: '바르셀로나' },
+        { id: 2, place: '브라질' },
+        { id: 3, place: '방콕' },
+        { id: 4, place: '부산' },
+        { id: 5, place: '베트남' },
+        { id: 6, place: '브루클린' },
+        { id: 7, place: '벨기에' },
+    ];
+    const onClick = (refCity: string) => {
+        alert(`${refCity} 담기 완료!`);
+    };
+
     return (
-        <Modal
-            modalMode={0}
-            title='일정 상세보기'
+        <div>
+            {refCities.map((refCity, index) => {
+                return (
+                    <div className="border-b border-lightgrey py-[14px]" key={index}>
+                        <div className='flex justify-between items-center'>
+                            <div className='flex'>
+                                <BiSearch size={24} className='mr-3' />
+                                {refCity.place}
+                            </div>
+                            <button 
+                                className='px-4 py-2 rounded-full bg-lightgrey'
+                                onClick={() => onClick(refCity.place)}>
+                                <div className='text-[12px]'>선택</div>
+                            </button>
+                        </div>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function SearchboxModal ({ setIsModal }: any) {
+    return (
+        <TransparentModal
+            modalMode={1}
+            title=''
             setModalState={setIsModal}
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''
         >
-            <div className='flex flex-col-reverse'>
-                <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
-                <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
+            <div className='px-[30px] pt-2'>
+                <div className='border-b border-grey'></div>
+                <div className='p-3.5'>
+                    <City />
                 </div>
             </div>
-        </Modal>
+        </TransparentModal>
     );
 };
 

--- a/src/components/modal/SearchboxModal.tsx
+++ b/src/components/modal/SearchboxModal.tsx
@@ -1,9 +1,15 @@
 // SearchboxModal.tsx
-import React from 'react';
+import React, { useState } from 'react';
 import TransparentModal from './TransparentModal';
 import { BiSearch } from 'react-icons/bi';
+import { RxCross1 } from 'react-icons/rx';
 
-function City() {
+interface CityProps {
+    selectedCities: string[];
+    setSelectedCities: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+function City({ selectedCities, setSelectedCities }: CityProps) {
     const refCities = [ // 자동완성 검색어
         { id: 1, place: '바르셀로나' },
         { id: 2, place: '브라질' },
@@ -13,11 +19,58 @@ function City() {
         { id: 6, place: '브루클린' },
         { id: 7, place: '벨기에' },
     ];
+    
     const onClick = (refCity: string) => {
-        alert(`${refCity} 담기 완료!`);
+        if (!selectedCities.includes(refCity)) { // 이미 선택된 도시가 아니면
+            setSelectedCities(prevCities => [...prevCities, refCity]); // 배열에 삽입
+        }
+    };
+    const onRemoveCity = (city: string) => { // 선택된 도시 삭제
+        setSelectedCities(prevCities => prevCities.filter(item => item !== city));
     };
 
-    return (
+    if (selectedCities.length > 0) { // 도시를 선택한 경우
+        return (
+            <div>
+                <div className='flex'>
+                    {selectedCities.map((city, index) => (
+                        <div className='flex text-center px-3 py-2 mr-2 rounded-full border border-grey text-[12px] text-darkgrey' key={index}>
+                            {city}
+                            <button 
+                                className='pl-2 pb-0.5' // RxCross가 중앙에 위치하기 위해 pb-0.5
+                                onClick={() => onRemoveCity(city)}
+                            >
+                                <RxCross1 size={12}/>
+                            </button>
+                        </div>
+                    ))}
+                    <button className='px-3 py-2 rounded-full bg-primary text-[12px]'>
+                        일정 생성
+                    </button>
+                </div>
+                <div>
+                    {refCities.map((refCity, index) => {
+                        return (
+                            <div className="border-b border-lightgrey py-[14px]" key={index}>
+                                <div className='flex justify-between items-center'>
+                                    <div className='flex'>
+                                        <BiSearch size={24} className='mr-3' />
+                                        {refCity.place}
+                                    </div>
+                                    <button 
+                                        className='px-4 py-2 rounded-full bg-lightgrey text-[12px]'
+                                        onClick={() => onClick(refCity.place)}>
+                                        선택
+                                    </button>
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            </div>
+        );
+    } 
+    return ( // 도시 선택 안한 최초 검색창
         <div>
             {refCities.map((refCity, index) => {
                 return (
@@ -41,6 +94,7 @@ function City() {
 }
 
 function SearchboxModal ({ setIsModal }: any) {
+    const [selectedCities, setSelectedCities] = useState<string[]>([]);
     return (
         <TransparentModal
             modalMode={1}
@@ -52,7 +106,10 @@ function SearchboxModal ({ setIsModal }: any) {
             <div className='px-[30px] pt-2'>
                 <div className='border-b border-grey'></div>
                 <div className='p-3.5'>
-                    <City />
+                    <City
+                        selectedCities={selectedCities} // City 컴포넌트에 선택된 도시들을 props로 전달
+                        setSelectedCities={setSelectedCities} // City 컴포넌트에서 선택된 도시들을 수정하는 함수를 props로 전달
+                    />
                 </div>
             </div>
         </TransparentModal>

--- a/src/components/modal/TransparentModal.tsx
+++ b/src/components/modal/TransparentModal.tsx
@@ -58,20 +58,13 @@ export default function TransparentModal({
     ];
 
     useEffect(() => {
-        // 모달이 열릴 때 body에 padding-right를 추가하여 스크롤을 없애기
-        document.body.style.overflow = 'hidden';
-        document.body.style.paddingRight = '1px';
+        // 모달이 열릴 때 가로 스크롤을 없애기
+        document.body.style.overflowX = 'hidden';
 
         // 모달 내용의 높이 측정하여 state에 저장
         if (contentRef.current) {
             setContentHeight(contentRef.current.offsetHeight);
         }
-        
-        return () => {
-            // 모달이 닫힐 때 padding-right를 제거하여 스크롤 복구
-            document.body.style.overflow = 'unset';
-            document.body.style.paddingRight = '0';
-        };
     }, []);
 
     return (

--- a/src/components/modal/TransparentModal.tsx
+++ b/src/components/modal/TransparentModal.tsx
@@ -1,0 +1,95 @@
+// TransparentModal.tsx
+
+import React, { useEffect, useRef, useState } from 'react';
+import Portal from '@/components/modal/Portal';
+import { IoCloseOutline } from 'react-icons/io5';
+
+//mode
+// 끄기만 있는거, => 확인버튼이 아래
+// 취소, 완료 있는거 => 확인버튼이 완료
+
+type Props = {
+    modalMode: Number;
+    title?: String;
+    setModalState: Function;
+    children: React.ReactNode;
+    onClickCompleteButton: Function;
+    completeText: String;
+};
+
+export default function TransparentModal({
+    modalMode,
+    setModalState,
+    title,
+    children,
+    onClickCompleteButton,
+    completeText
+}: Props) {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [contentHeight, setContentHeight] = useState<number>(0);
+
+    const transparentModal: React.ReactNode[] = [
+        <>
+            <div className='flex basis-[15%] justify-between items-center px-5 p-4'>
+                <div className='font-bold text-xl'>{title}</div>
+                <button
+                    className='items-center'
+                    onClick={() => {
+                        setModalState(false);
+                    }}
+                >
+                    <IoCloseOutline size='40px' />
+                </button>
+            </div>
+            <div className='basis-[70%]'>{children}</div>
+            <button
+                className='grow justify-center items-center rounded-b-lg border-t border-gray-200 bg-gray-50'
+                onClick={() => onClickCompleteButton()}
+            >
+                <span className='text-xl'>{completeText}</span>
+            </button>
+        </>,
+        <>
+            {/* 모달 내용의 높이를 측정하여 state에 저장 */}
+            <div ref={contentRef} className='basis-[85%]'>
+                {children}
+            </div>
+        </>
+    ];
+
+    useEffect(() => {
+        // 모달이 열릴 때 body에 padding-right를 추가하여 스크롤을 없애기
+        document.body.style.overflow = 'hidden';
+        document.body.style.paddingRight = '1px';
+
+        // 모달 내용의 높이 측정하여 state에 저장
+        if (contentRef.current) {
+            setContentHeight(contentRef.current.offsetHeight);
+        }
+        
+        return () => {
+            // 모달이 닫힐 때 padding-right를 제거하여 스크롤 복구
+            document.body.style.overflow = 'unset';
+            document.body.style.paddingRight = '0';
+        };
+    }, []);
+
+    return (
+        <Portal selector='#body'>
+            <div className='flex justify-center items-center'>
+                <div
+                    className='absolute top-0 left-0 w-screen h-screen'
+                    onClick={() => {
+                        setModalState(false);
+                    }}
+                ></div>
+                <div
+                    className='absolute flex flex-col top-[345px] w-[690px] rounded-lg bg-white z-101 shadow-md'
+                    style={{ height: `${contentHeight}px`, minHeight: '6rem', maxHeight: '30rem' }}
+                >
+                    {transparentModal[modalMode as number]}
+                </div>
+            </div>
+        </Portal>
+    );
+}

--- a/src/components/modal/TransparentModal.tsx
+++ b/src/components/modal/TransparentModal.tsx
@@ -78,7 +78,7 @@ export default function TransparentModal({
                 ></div>
                 <div
                     className='absolute flex flex-col top-[345px] w-[690px] rounded-lg bg-white z-101 shadow-md'
-                    style={{ height: `${contentHeight}px`, minHeight: '6rem', maxHeight: '30rem' }}
+                    style={{ height: `${contentHeight}px`, minHeight: '6rem'}}
                 >
                     {transparentModal[modalMode as number]}
                 </div>

--- a/src/components/schedulemain/detailBox.tsx
+++ b/src/components/schedulemain/detailBox.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { AiOutlineCalendar } from 'react-icons/ai';
 import format from "date-fns/format";
 import 'react-datepicker/dist/react-datepicker.css';
 import Calendar from "../infocity/Calendar";
-import SearchboxModal from "../modal/SearchboxModal";
 import HotSearch from "./hotSearch";
+import SelectedPlaces from "./selectedPlaces";
 
 interface MenuProps {
     menu: string;
@@ -41,9 +41,12 @@ function RoundBtn (props: RoundBtnProps) {
     )
 }
 
+interface DetailBoxProps {
+    selectedCities: string[];
+    setSelectedCities: React.Dispatch<React.SetStateAction<string[]>>;
+}
 
-
-function DetailBox () {
+function DetailBox ({ selectedCities, setSelectedCities }: DetailBoxProps) {
     const [menus, setMenus] = useState<[string, boolean][]>([
         ["해외", true],
         ["국내", false]
@@ -109,7 +112,7 @@ function DetailBox () {
             </div>
         );
     };
-    const [selectedCities, setSelectedCities] = useState<string[]>([]);
+
     return (
         <div className="mt-12">
             {/* 해외, 국내 탭바 */}
@@ -132,7 +135,11 @@ function DetailBox () {
                     <RoundBtn color="lightgrey" label="검색" />
             </div>
             {/* 인기 검색어 */}
-            <HotSearch selectedCities={selectedCities}/>
+            {selectedCities.length > 0 ? (
+                <SelectedPlaces selectedCities={selectedCities} setSelectedCities={setSelectedCities}/> 
+                ) : (
+                <HotSearch />
+            )}
             {/* 날짜 선택창 */}
             <div className="flex flex-row justify-between mx-2.5">
                 <SelectDates title='출발일' value={startDate} />

--- a/src/components/schedulemain/detailBox.tsx
+++ b/src/components/schedulemain/detailBox.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { AiOutlineCalendar } from 'react-icons/ai';
 import format from "date-fns/format";
-import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-import { ko } from 'date-fns/locale';
 import Calendar from "../infocity/Calendar";
+import SearchboxModal from "../modal/SearchboxModal";
+import HotSearch from "./hotSearch";
 
 interface MenuProps {
     menu: string;
@@ -40,6 +40,8 @@ function RoundBtn (props: RoundBtnProps) {
         </button>
     )
 }
+
+
 
 function DetailBox () {
     const [menus, setMenus] = useState<[string, boolean][]>([
@@ -83,14 +85,6 @@ function DetailBox () {
         setMenus(updatedMenus);
     };
 
-    const [cities, setCities] = useState([
-        "런던",
-        "제주도",
-        "대만",
-        "도쿄",
-        "하와이",
-    ])
-
     // 날짜 선택 부분
     const [startDate, setStartDate] = useState<null | Date>(null);
     const [endDate, setEndDate] = useState<null | Date>(null);
@@ -115,7 +109,7 @@ function DetailBox () {
             </div>
         );
     };
-
+    const [selectedCities, setSelectedCities] = useState<string[]>([]);
     return (
         <div className="mt-12">
             {/* 해외, 국내 탭바 */}
@@ -138,19 +132,7 @@ function DetailBox () {
                     <RoundBtn color="lightgrey" label="검색" />
             </div>
             {/* 인기 검색어 */}
-            <div className="flex flex-col bg-brightgrey rounded-md px-[33px] py-2.5 mx-4">
-                <div className="py-2.5">
-                    인기 검색어
-                </div>
-                <div className="flex flex-col">
-                    {cities.map((city, index) => (
-                        <div key={index} className="flex items-start py-2.5">
-                            <span className="text-grey mr-4">{index + 1}</span>
-                            <button>{city}</button>
-                        </div>
-                    ))}
-                </div>
-            </div>
+            <HotSearch selectedCities={selectedCities}/>
             {/* 날짜 선택창 */}
             <div className="flex flex-row justify-between mx-2.5">
                 <SelectDates title='출발일' value={startDate} />

--- a/src/components/schedulemain/hotSearch.tsx
+++ b/src/components/schedulemain/hotSearch.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react"
-interface HotSearchProps {
-    selectedCities: string[];
-}
-export default function HotSearch(props: HotSearchProps) {
+
+export default function HotSearch() {
     const [cities, setCities] = useState([
         "런던",
         "제주도",
@@ -10,7 +8,6 @@ export default function HotSearch(props: HotSearchProps) {
         "도쿄",
         "하와이",
     ])
-    const [selectedCities, setSelectedCities] = useState<string[]>([]);
     return (
         <div className="flex flex-col bg-brightgrey rounded-md px-[33px] py-2.5 mx-4">
             <div className="py-2.5">
@@ -24,11 +21,6 @@ export default function HotSearch(props: HotSearchProps) {
                     </div>
                 ))}
             </div>
-            {/* 추가: 선택된 도시 출력 */}    
-            {selectedCities.length > 0 && (
-            <div className="py-2.5">선택된 도시: {selectedCities.join(", ")}</div>
-            )}
-        </div>
-        
+        </div>      
     )
 }

--- a/src/components/schedulemain/hotSearch.tsx
+++ b/src/components/schedulemain/hotSearch.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react"
+interface HotSearchProps {
+    selectedCities: string[];
+}
+export default function HotSearch(props: HotSearchProps) {
+    const [cities, setCities] = useState([
+        "런던",
+        "제주도",
+        "대만",
+        "도쿄",
+        "하와이",
+    ])
+    const [selectedCities, setSelectedCities] = useState<string[]>([]);
+    return (
+        <div className="flex flex-col bg-brightgrey rounded-md px-[33px] py-2.5 mx-4">
+            <div className="py-2.5">
+                인기 검색어
+            </div>
+            <div className="flex flex-col">
+                {cities.map((city, index) => (
+                    <div key={index} className="flex items-start py-2.5">
+                        <span className="text-grey mr-4">{index + 1}</span>
+                        <button>{city}</button>
+                    </div>
+                ))}
+            </div>
+            {/* 추가: 선택된 도시 출력 */}    
+            {selectedCities.length > 0 && (
+            <div className="py-2.5">선택된 도시: {selectedCities.join(", ")}</div>
+            )}
+        </div>
+        
+    )
+}

--- a/src/components/schedulemain/scheduleHeader.tsx
+++ b/src/components/schedulemain/scheduleHeader.tsx
@@ -1,6 +1,7 @@
+// scheduleHeader.tsx
+
 import { BiSearch, BiX } from "react-icons/bi";
 import { useState } from "react";
-
 import SearchboxModal from "../modal/SearchboxModal";
 
 
@@ -19,7 +20,7 @@ function City () {
             {searchedCities.map((searchedCity, index) => {
                 return (
                     <div className="border border-grey rounded-full mx-2" key={index}>
-                        <div className="flex px-2 py-1  text-[14px]">
+                        <div className="flex px-2 py-1 text-[12px]">
                             {searchedCities[index]}
                             <button
                                 className="px-1"
@@ -49,7 +50,7 @@ function ScheduleHeader () {
                 </div>
                 <div className="flex relative justify-center">
                     <input 
-                        className="border-b border-grey w-[630px] pb-5 pl-5"
+                        className="border-b border-grey w-[630px] pb-5 pl-5 focus:outline-none"
                         type="text" 
                         placeholder="여행일정을 생성할 도시를 입력하세요"
                         onClick={() => setModal(true)}
@@ -67,7 +68,9 @@ function ScheduleHeader () {
                 </div>
             </div>
             {modal && (
-                <SearchboxModal />
+                <div className="flex justify-center items-center">
+                    <SearchboxModal setIsModal={setModal} />
+                </div>
             )}
         </div>
     )

--- a/src/components/schedulemain/scheduleHeader.tsx
+++ b/src/components/schedulemain/scheduleHeader.tsx
@@ -1,8 +1,8 @@
-// scheduleHeader.tsx
-
-import { BiSearch, BiX } from "react-icons/bi";
 import { useState } from "react";
 import SearchboxModal from "../modal/SearchboxModal";
+
+import { BiSearch } from "react-icons/bi";
+import { RxCross1 } from 'react-icons/rx';
 
 
 function City () {
@@ -20,15 +20,13 @@ function City () {
             {searchedCities.map((searchedCity, index) => {
                 return (
                     <div className="border border-grey rounded-full mx-2" key={index}>
-                        <div className="flex px-2 py-1 text-[12px]">
+                        <div className="flex px-3 py-2 text-[12px]">
                             {searchedCities[index]}
                             <button
-                                className="px-1"
+                                className="pl-2 pb-0.5" // RxCross가 중앙에 위치하기 위해 pb-0.5
                                 onClick={() => onClick(searchedCity)}
                             >
-                                <BiX 
-                                    size={16}
-                                />
+                                <RxCross1 size={12}/>
                             </button>
                         </div>
                     </div>

--- a/src/components/schedulemain/scheduleHeader.tsx
+++ b/src/components/schedulemain/scheduleHeader.tsx
@@ -1,5 +1,7 @@
 import { BiSearch, BiX } from "react-icons/bi";
+import { useState } from "react";
 
+import SearchboxModal from "../modal/SearchboxModal";
 
 
 function City () {
@@ -36,6 +38,9 @@ function City () {
 }
 
 function ScheduleHeader () {
+    // 모달 상태 제어
+    const [modal, setModal] = useState(false);
+
     return (
         <div className="flex justify-center">
             <div className="flex-col text-center">
@@ -47,6 +52,7 @@ function ScheduleHeader () {
                         className="border-b border-grey w-[630px] pb-5 pl-5"
                         type="text" 
                         placeholder="여행일정을 생성할 도시를 입력하세요"
+                        onClick={() => setModal(true)}
                     />
                     <BiSearch   
                             size={32}
@@ -60,6 +66,9 @@ function ScheduleHeader () {
                     </div>
                 </div>
             </div>
+            {modal && (
+                <SearchboxModal />
+            )}
         </div>
     )
 }

--- a/src/components/schedulemain/scheduleHeader.tsx
+++ b/src/components/schedulemain/scheduleHeader.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import SearchboxModal from "../modal/SearchboxModal";
-
 import { BiSearch } from "react-icons/bi";
 import { RxCross1 } from 'react-icons/rx';
 
@@ -19,7 +18,7 @@ function City () {
         <div className="flex">
             {searchedCities.map((searchedCity, index) => {
                 return (
-                    <div className="border border-grey rounded-full mx-2" key={index}>
+                    <div className="border border-grey rounded-full mr-2" key={index}>
                         <div className="flex px-3 py-2 text-[12px]">
                             {searchedCities[index]}
                             <button
@@ -36,7 +35,13 @@ function City () {
     )
 }
 
-function ScheduleHeader () {
+interface ScheduleHeaderProps {
+    selectedCities: string[];
+    setSelectedCities: React.Dispatch<React.SetStateAction<string[]>>;
+    onCreateSchedule: () => void;
+}
+
+function ScheduleHeader ({ selectedCities, setSelectedCities, onCreateSchedule }: ScheduleHeaderProps) {
     // 모달 상태 제어
     const [modal, setModal] = useState(false);
 
@@ -59,7 +64,7 @@ function ScheduleHeader () {
                     />
                 </div>
                 <div className="flex my-[25px] items-center">
-                    최근 검색어
+                    <span className="mr-2">최근 검색어</span>
                     <div className="mx-2">
                         <City /> {/* 최근 검색어 map으로 출력 */}
                     </div>
@@ -67,7 +72,12 @@ function ScheduleHeader () {
             </div>
             {modal && (
                 <div className="flex justify-center items-center">
-                    <SearchboxModal setIsModal={setModal} />
+                    <SearchboxModal 
+                        setIsModal={setModal} 
+                        selectedCities={selectedCities} 
+                        setSelectedCities={setSelectedCities} 
+                        onCreateSchedule={() => {}}
+                    />
                 </div>
             )}
         </div>

--- a/src/components/schedulemain/scheduleMain.tsx
+++ b/src/components/schedulemain/scheduleMain.tsx
@@ -1,14 +1,21 @@
+import React, { useState } from "react";
 import DetailBox from "./detailBox";
 import MyTravel from "./myTravel";
 import ScheduleHeader from "./scheduleHeader";
 
 function scheduleMain () {
+    const [selectedCities, setSelectedCities] = useState<string[]>([]);
+    
     return (
         <div>
             {/* 상단 검색창 */}
-            <ScheduleHeader />
+            <ScheduleHeader 
+                selectedCities={selectedCities} 
+                setSelectedCities={setSelectedCities} 
+                onCreateSchedule={() => {}}
+            />
             {/* 하단 검색창 */}
-            <DetailBox />     
+            <DetailBox selectedCities={selectedCities} setSelectedCities={setSelectedCities}/>     
             {/* 내 여행 목록 */}
             <MyTravel /> 
         </div>

--- a/src/components/schedulemain/selectedPlaces.tsx
+++ b/src/components/schedulemain/selectedPlaces.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { RxCross1 } from "react-icons/rx"
+
+interface SelectedPlacesProps {
+    selectedCities: string[];
+    setSelectedCities: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+export default function SelectedPlaces({ selectedCities, setSelectedCities }: SelectedPlacesProps) {
+    const onRemoveCity = (city: string) => { // 선택된 도시 삭제
+        setSelectedCities(prevCities => prevCities.filter(item => item !== city));
+    };
+
+    return (
+        <div className="flex flex-col bg-brightgrey rounded-md px-[33px] py-2.5 mx-4">
+            <div className="py-2.5">
+                여행 일정 등록하기
+            </div>
+            <div className='flex py-2.5'>
+                    {selectedCities.map((city, index) => (
+                        <div className='flex text-center px-3 py-2 mr-2 rounded-full border border-grey text-[12px] text-darkgrey' key={index}>
+                            {city}
+                            <button 
+                                className='pl-2 pb-0.5' // RxCross가 중앙에 위치하기 위해 pb-0.5
+                                onClick={() => onRemoveCity(city)}
+                            >
+                                <RxCross1 size={12}/>
+                            </button>
+                        </div>
+                    ))}
+                </div>
+        </div>      
+    )
+}


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #51  - 여행계획 메인페이지 검색 모달창

📋 PR Checklist
- [ ] 선택한 여행지가 selectedCities 배열에 담기는지 확인
- [ ] '일정 생성'버튼을 누르거나 화면 밖을 눌렀을때 검색 모달창 닫힘 확인
- [ ] '여행 일정 등록하기'에 담은 여행지를 모두 없애면 기존의 '인기 검색어' 컴포넌트 다시 렌더링

📌 유의사항
- '일정 생성' 버튼을 눌러야 컴포넌트가 바뀌도록 하고 싶었는데... 이부분은 실패했습니다
- 또한 여행지를 선택하면 검색창의 크기가 늘어나야 하는데 아래 사진과 같이 크기가 실시간으로 변하지 않습니다 ㅜ 물론 닫았다가 다시 펼치면 늘어난 검색창 크기가 제대로 적용됩니다!

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/1e4e41bc-c2f2-48b3-83dc-2f6d7011110b)
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/acfeaddf-af4a-4151-97e2-d8be2d92c2fa)
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/c0e02e1f-00ed-484f-93a0-bf82ec149169)
