### PR TITLE
[FEAT] 정보 페이지 위치에 따른 메뉴 색상 변경

### DIFF
--- a/src/components/infocity/InfoCity.tsx
+++ b/src/components/infocity/InfoCity.tsx
@@ -4,6 +4,7 @@ import InfoWeather from './InfoWeather';
 import ExchangeRate from './ExchangeRate';
 import format from 'date-fns/format';
 import Calendar from './Calendar';
+import Image from 'next/image';
 
 export default function InfoCity() {
     const [startDate, setStartDate] = useState<Date | null>(null);
@@ -32,7 +33,12 @@ export default function InfoCity() {
     };
     return (
         <div className='flex justify-between mt-28'>
-            <img src='/images/location.png' alt='none' />
+            <Image
+                src='/images/location.png'
+                alt='none'
+                width={522}
+                height={522}
+            />
             <div className='h-11/12  flex flex-col justify-between'>
                 <div className='text-5xl font-bold  '>도쿄</div>
                 {/* 날씨 부분 */}

--- a/src/components/infocity/InfoCity.tsx
+++ b/src/components/infocity/InfoCity.tsx
@@ -31,7 +31,7 @@ export default function InfoCity() {
         );
     };
     return (
-        <div className='flex justify-between mt-32'>
+        <div className='flex justify-between mt-28'>
             <img src='/images/location.png' alt='none' />
             <div className='h-11/12  flex flex-col justify-between'>
                 <div className='text-5xl font-bold  '>도쿄</div>

--- a/src/components/infomenu/InfoMenus.tsx
+++ b/src/components/infomenu/InfoMenus.tsx
@@ -8,15 +8,6 @@ interface MenuProps {
     onClick: (index: number) => void;
 }
 
-interface Props {
-    menu: string;
-    select: boolean;
-    location: {
-        min: number;
-        max: number;
-    };
-}
-
 export default function InfoMenus() {
     const [menus, setMenus] = useState<
         [string, boolean, { min: number; max: number }][]
@@ -24,8 +15,7 @@ export default function InfoMenus() {
         ['메인', true, { min: 0, max: 800 }],
         ['명소', false, { min: 800, max: 2025 }],
         ['준비물', false, { min: 2025, max: 2525 }],
-        ['후기', false, { min: 2525, max: 2820 }],
-        ['회화', false, { min: 2820, max: 5000 }]
+        ['후기/회화', false, { min: 2525, max: 5000 }]
     ]);
     const [place, setPlace] = useState<string>('');
 

--- a/src/components/infomenu/InfoMenus.tsx
+++ b/src/components/infomenu/InfoMenus.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { BiSearch } from 'react-icons/bi';
 
 interface MenuProps {
@@ -8,13 +8,24 @@ interface MenuProps {
     onClick: (index: number) => void;
 }
 
+interface Props {
+    menu: string;
+    select: boolean;
+    location: {
+        min: number;
+        max: number;
+    };
+}
+
 export default function InfoMenus() {
-    const [menus, setMenus] = useState<[string, boolean][]>([
-        ['메인', true],
-        ['명소', false],
-        ['준비물', false],
-        ['후기', false],
-        ['회화', false]
+    const [menus, setMenus] = useState<
+        [string, boolean, { min: number; max: number }][]
+    >([
+        ['메인', true, { min: 0, max: 800 }],
+        ['명소', false, { min: 800, max: 2025 }],
+        ['준비물', false, { min: 2025, max: 2525 }],
+        ['후기', false, { min: 2525, max: 2820 }],
+        ['회화', false, { min: 2820, max: 5000 }]
     ]);
     const [place, setPlace] = useState<string>('');
 
@@ -43,15 +54,30 @@ export default function InfoMenus() {
     };
 
     const menuClick = (selectedIndex: number) => {
-        const updatedMenus: [string, boolean][] = menus.map((menu, index) => [
-            menu[0],
-            index === selectedIndex
-        ]);
+        const updatedMenus: [string, boolean, { min: number; max: number }][] =
+            menus.map((menu, index) => [
+                menu[0],
+                index === selectedIndex,
+                menu[2]
+            ]);
+        scrollTo({ top: menus[selectedIndex][2].min, behavior: 'smooth' });
         setMenus(updatedMenus);
     };
 
+    window.addEventListener('scroll', () => {
+        const updatedMenus: [string, boolean, { min: number; max: number }][] =
+            menus.map((menu, index) => [
+                menu[0],
+                scrollY >= menu[2].min && scrollY < menu[2].max,
+                menu[2]
+            ]);
+        setMenus(updatedMenus);
+    });
+
+    useEffect(() => {}, [menus]);
+
     return (
-        <div className='flex justify-between mt-6'>
+        <div className='flex justify-between py-6 sticky top-0 bg-white z-10'>
             <div className='flex items-end'>
                 {menus.map((menu, index) => (
                     <Menu


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #57 - 정보 페이지 위치에 따른 메뉴 색상 변경
<img width="1440" alt="스크린샷 2023-08-03 오전 12 58 05" src="https://github.com/UMC-TRIPY/web-front/assets/114225974/c228c8f7-bdca-4873-b263-a4460a3d127c">

📋 PR Checklist
- [ ] 스크롤 위치에 따른 메뉴 색상 변경 확인
- [ ] 메뉴 클릭 시 해당 위치로 이동하는지 확인

📌 유의사항
- 
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
