### PR TITLE
[FEAT] 가방만들기 상세보기 모달

### DIFF
--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -1,7 +1,7 @@
 import { CiLocationOn } from 'react-icons/ci';
 
 interface ILabelScheduleProps {
-    status: 'page' | 'modal';
+    status: 'page' | 'modal' | 'modal2';
 }
 
 export default function LabelSchedules({ status }: ILabelScheduleProps) {
@@ -224,18 +224,30 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                             {schedule.todos.map((todo, idx) => (
                                 <div
                                     key={idx}
-                                    className={`border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${todo.color}`}
+                                    className={`flex items-center justify-between border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${todo.color}`}
                                 >
-                                    <div className='text-xs text-grey pb-2'>
-                                        {todo.time}
-                                    </div>
-                                    <div className='flex justify-between'>
-                                        <div className='flex flex-col'>
-                                            <div>{todo.content}</div>
-                                            <div className='text-grey'>
-                                                {todo.additional}
+                                    <div>
+                                        <div className='text-xs text-grey pb-2'>
+                                            {todo.time}
+                                        </div>
+                                        <div className='flex justify-between'>
+                                            <div className='flex flex-col'>
+                                                <div>{todo.content}</div>
+                                                <div className='text-grey'>
+                                                    {todo.additional}
+                                                </div>
                                             </div>
                                         </div>
+                                    </div>
+                                    <div>
+                                    {status === 'modal2' && ( // modal2일 때 체크박스
+                                        <div className='flex items-center'>
+                                            <input
+                                                type='checkbox'
+                                                className='mr-2'
+                                            />
+                                        </div>
+                                    )}
                                     </div>
                                 </div>
                             ))}

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { CiLocationOn } from 'react-icons/ci';
 
 interface ILabelScheduleProps {
@@ -5,7 +6,7 @@ interface ILabelScheduleProps {
 }
 
 export default function LabelSchedules({ status }: ILabelScheduleProps) {
-    const schedules = [
+    const [schedules, setSchedules] = useState([
         {
             date: '6월30일(토)',
             todos: [
@@ -14,49 +15,56 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                     time: '7:30 AM~8:30 AM',
                     content: '기상 및 숙소에서 출발',
                     additional: 'F1963 전시회 티켓 오픈, 예매하기',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-tag-red',
                     time: '8:30 AM~1:00 PM',
                     content: '자차로 이동',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '1:00 PM~2:00 PM',
                     content: '점심',
                     additional: '',
-                    place: '바릇'
+                    place: '바릇', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '2:30 PM~4:30 PM',
                     content: '카페',
                     additional: '',
-                    place: '힐튼 부산 호텔'
+                    place: '힐튼 부산 호텔', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '5:00 PM~6:00 PM',
                     content: 'F1963',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-tag-blue',
                     time: '6:30 PM~7:00 PM',
                     content: '숙소 체크인 & 짐정리',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '7:30 PM~8:30 PM',
                     content: '저녁',
                     additional: '',
-                    place: '부산 해운대 시장'
+                    place: '부산 해운대 시장', 
+                    checked: false
                 }
             ]
         },
@@ -68,21 +76,24 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                     time: '7:30 AM~8:30 AM',
                     content: '기상 및 숙소에서 출발',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '9:00 AM ~ 10:00AM',
                     content: '아침',
                     additional: '',
-                    place: '해목 해운대점'
+                    place: '해목 해운대점', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '10:30 AM ~ 8:30 PM',
                     content: '부산 롯데월드',
                     additional: '안에서 점심, 저녁 먹기',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 }
             ]
         },
@@ -94,60 +105,93 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                     time: '8:30 AM~9:30 AM',
                     content: '기상 및 숙소에서 출발',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '10:00 AM ~ 11:00 AM',
                     content: '아침',
                     additional: '',
-                    place: '밀양순대돼지국밥 부산본점'
+                    place: '밀양순대돼지국밥 부산본점', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '11:15 AM ~ 11:30 AM',
                     content: '해운대',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-tag-blue',
                     time: '11:30 AM ~ 12:00 AM',
                     content: '나가하마만게츠 현장 테이블링',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '12:00 PM ~ 1:00 PM',
                     content: '점심',
                     additional: '',
-                    place: '나가하마만게츠'
+                    place: '나가하마만게츠', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '1:30 PM ~ 2:30 PM',
                     content: '동백섬',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-primary',
                     time: '3:30 PM ~ 4:30 PM',
                     content: '해리단길',
                     additional: '',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 },
                 {
                     color: 'border-l-tag-red',
                     time: '4:30 PM ~ 9:30 PM',
                     content: '집 가기',
                     additional: '중간에 휴게소 들러서 저녁먹기!',
-                    place: '장소 등록'
+                    place: '장소 등록', 
+                    checked: false
                 }
             ]
         }
-    ];
+    ]);
+
+    const handleCheckboxChange = (dayIndex: number, todoIndex: number) => {
+        setSchedules(prevSchedules => {
+            const updatedSchedules = prevSchedules.map((schedule, sIndex) => {
+                if (sIndex !== dayIndex) {
+                    return schedule;
+                }
+                const updatedTodos = schedule.todos.map((todo, tIndex) => {
+                    if (tIndex !== todoIndex) {
+                        return todo;
+                    }
+                    return {
+                        ...todo,
+                        checked: !todo.checked
+                    };
+                });
+                return {
+                    ...schedule,
+                    todos: updatedTodos
+                };
+            });
+            return updatedSchedules;
+        });
+    };
+
     return (
         <>
             {status === 'page' ? (
@@ -224,7 +268,7 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                             {schedule.todos.map((todo, idx) => (
                                 <div
                                     key={idx}
-                                    className={`flex items-center justify-between border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${todo.color}`}
+                                    className={`flex items-center justify-between border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${todo.color} ${todo.checked ? 'bg-lightgrey' : ''}`}
                                 >
                                     <div>
                                         <div className='text-xs text-grey pb-2'>
@@ -245,6 +289,8 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                                             <input
                                                 type='checkbox'
                                                 className='mr-2'
+                                                checked={todo.checked}
+                                                onChange={() => handleCheckboxChange(index, idx)} // 해당 스케줄의 체크박스가 체크되면 상태 업데이트 함수 호출
                                             />
                                         </div>
                                     )}

--- a/src/components/modal/BagpackingModal.tsx
+++ b/src/components/modal/BagpackingModal.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import LabelSchedules from '../detailschedule/LabelSchedules';
+import Modal from './Modal';
+
+const BagPackingModal = ({ setIsModal, selectedPlace }: any) => {
+    return (
+        <Modal
+            modalMode={0}
+            title={`${selectedPlace} 일정 상세보기`}
+            setModalState={setIsModal}
+            onClickCompleteButton={() => setIsModal(false)}
+            completeText=''
+        >
+            <div className='flex flex-col-reverse'>
+                <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
+                <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
+                    <LabelSchedules status='modal2' />
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default BagPackingModal;

--- a/src/components/modal/BagpackingModal.tsx
+++ b/src/components/modal/BagpackingModal.tsx
@@ -13,10 +13,9 @@ const BagPackingModal = ({ setIsModal, selectedPlace }: any) => {
         >
             <div className='flex flex-col-reverse'>
                 <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
-                <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
+                <div className='h-96 overflow-scroll pl-8 pr-8 mb-12 overflow-x-hidden'>
                     <LabelSchedules status='modal2' />
                 </div>
-                <button>가방 만들기</button>
             </div>
         </Modal>
     );

--- a/src/components/modal/MyBagModal.tsx
+++ b/src/components/modal/MyBagModal.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import LabelSchedules from '../detailschedule/LabelSchedules';
 import Modal from './Modal';
+import DetailBag from '../mybag/DetailBag';
 
-const BagPackingModal = ({ setIsModal, selectedPlace }: any) => {
+const MyBagModal = ({ setIsModal, selectedPlace }: any) => {
     return (
         <Modal
             modalMode={0}
-            title={`${selectedPlace} 일정 상세보기`}
+            title={`${selectedPlace} 준비물 상세보기`}
             setModalState={setIsModal}
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''
@@ -14,12 +14,11 @@ const BagPackingModal = ({ setIsModal, selectedPlace }: any) => {
             <div className='flex flex-col-reverse'>
                 <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
                 <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
-                    <LabelSchedules status='modal2' />
+                    <DetailBag />
                 </div>
-                <button>가방 만들기</button>
             </div>
         </Modal>
     );
 };
 
-export default BagPackingModal;
+export default MyBagModal;

--- a/src/components/modal/MyBagModal.tsx
+++ b/src/components/modal/MyBagModal.tsx
@@ -13,7 +13,7 @@ const MyBagModal = ({ setIsModal, selectedPlace }: any) => {
         >
             <div className='flex flex-col-reverse'>
                 <div className='absolute w-full h-1/5 bg-gradient-to-t from-blur to-blur-end to-100%'></div>
-                <div className='h-96 overflow-scroll pl-8 pr-8 overflow-x-hidden'>
+                <div className='h-96 overflow-scroll pl-8 pr-8 mb-12 overflow-x-hidden'>
                     <DetailBag />
                 </div>
             </div>

--- a/src/components/mybag/DetailBag.tsx
+++ b/src/components/mybag/DetailBag.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+
+export default function DetailBag() {
+    const [bags, setBags] = useState([
+        {
+            bagId: 1,
+            type: "크로스 백",
+            supplies: [
+                { supId: 1, name: "지갑", checked: false },
+                { supId: 2, name: "자외선 차단제", checked: false },
+                { supId: 3, name: "여권", checked: false },
+                { supId: 4, name: "에어팟", checked: false },
+                { supId: 5, name: "필름 카메라", checked: false },
+                { supId: 6, name: "삼각대", checked: false },
+                { supId: 7, name: "뮤지엄패스", checked: false },
+                { supId: 8, name: "미니 파우치", checked: false },
+            ]
+        },
+        {
+            bagId: 2,
+            type: "캐리어",
+            supplies: [
+                { supId: 9, name: "옷", checked: false },
+                { supId: 10, name: "클렌징 폼", checked: false },
+                { supId: 11, name: "닌텐도 스위치", checked: false },
+                { supId: 12, name: "보조배터리", checked: false },
+                { supId: 13, name: "충전기", checked: false },
+                { supId: 14, name: "잠옷", checked: false },
+                { supId: 15, name: "속옷", checked: false },
+                { supId: 16, name: "양말", checked: false },
+            ]
+        }
+    ]);
+
+    const handleCheckboxChange = (bagId: number, supId: number) => {
+        setBags(prevBags => {
+            const updatedBags = prevBags.map((bag, idx) => {
+                if (idx !== bagId) {
+                    return bag;
+                }
+                const updatedSupplies = bag.supplies.map((supply, sId) => {
+                    if (sId !== supId) {
+                        return supply;
+                    }
+                    return {
+                        ...supply,
+                        checked: !supply.checked
+                    };
+                });
+                return {
+                    ...bag,
+                    supplies: updatedSupplies
+                };
+            });
+            return updatedBags;
+        });
+    };
+
+    return (
+        <div>
+            {bags.map((bag, bagId) => {
+                return (
+                    <div key={bagId} className="mb-7">
+                        <div className="text-grey border-b border-1-lightgrey pb-3">
+                            {bag.type}
+                        </div>
+                        {bag.supplies.map((supply, supId) => {
+                            return (
+                                <div 
+                                key={supId} 
+                                className={`flex justify-between border-b border-1-lightgrey py-4 pl-6 ${supply.checked ? 'line-through' : ''}`}
+                                >
+                                    {supply.name}
+                                    <div className='flex items-center'>
+                                        <input
+                                            type='checkbox'
+                                            className='mr-2'
+                                            checked={supply.checked}
+                                            onChange={() => handleCheckboxChange(bagId, supId)}
+                                        />
+                                    </div>
+                                </div>
+                            )
+                        })}    
+                    </div>
+                )
+            })}
+        </div>
+    )
+}

--- a/src/components/mybag/ListComp.tsx
+++ b/src/components/mybag/ListComp.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import RoundBtn from '../layout/roundBtn';
 import ScheduleDetailModal from '../modal/ScheduleDetailModal';
 import BagPackingModal from '../modal/BagpackingModal';
+import MyBagModal from '../modal/MyBagModal';
 
 interface Props {
     travels: {
@@ -105,6 +106,25 @@ export default function ListComp({ travels, name }: Props) {
     };
 
     const MyBagList = ({ travel, index }: MyBagProps) => {
+        const [modalInfo, setModalInfo] = useState({
+            isOpen: false,
+            selectedPlace: '',
+        });
+    
+        const handleModalOpen = (place: string) => {
+            setModalInfo({
+                isOpen: true,
+                selectedPlace: place,
+            });
+        };
+    
+        const handleModalClose = () => {
+            setModalInfo({
+                isOpen: false,
+                selectedPlace: '',
+            });
+        };
+
         return (
             <div className='flex items-center justify-between py-[16.5px]'>
                 <Content content={travel.dates} />
@@ -113,7 +133,7 @@ export default function ListComp({ travels, name }: Props) {
                     <RoundBtn 
                         label='상세보기' 
                         color='bg-lightgrey' 
-                        onClick={() => setModal(true)}
+                        onClick={() => handleModalOpen(travel.places)}
                     />
                     <RoundBtn
                         label='삭제하기'
@@ -121,6 +141,11 @@ export default function ListComp({ travels, name }: Props) {
                         onClick={() => onClick(index)}
                     />
                 </div>
+                {modalInfo.isOpen && (
+                    <div>
+                        <MyBagModal setIsModal={handleModalClose} selectedPlace={modalInfo.selectedPlace}/>
+                    </div>
+                )}
             </div>
         );
     };

--- a/src/components/mybag/ListComp.tsx
+++ b/src/components/mybag/ListComp.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import RoundBtn from '../layout/roundBtn';
+import ScheduleDetailModal from '../modal/ScheduleDetailModal';
+import BagPackingModal from '../modal/BagpackingModal';
 
 interface Props {
     travels: {
@@ -32,6 +34,8 @@ export default function ListComp({ travels, name }: Props) {
         useState<{ id: number; dates: string; places: string }[]>(travels);
     const [currentPage, setCurrentPage] = useState(1);
     const [travelsPerPage] = useState(8);
+    const [modal, setModal] = useState(false);
+
     const handlePrevClick = () => {
         setCurrentPage((prevPage) => prevPage - 1);
     };
@@ -59,14 +63,43 @@ export default function ListComp({ travels, name }: Props) {
     };
 
     const TravelList = ({ travel }: TravelProps) => {
+        const [modalInfo, setModalInfo] = useState({
+            isOpen: false,
+            selectedPlace: '',
+        });
+    
+        const handleModalOpen = (place: string) => {
+            setModalInfo({
+                isOpen: true,
+                selectedPlace: place,
+            });
+        };
+    
+        const handleModalClose = () => {
+            setModalInfo({
+                isOpen: false,
+                selectedPlace: '',
+            });
+        };
         return (
-            <div className='flex items-center justify-between py-[16.5px]'>
-                <Content content={travel.dates} />
-                <Content content={travel.places} />
-                <div className='flex w-1/3 justify-center'>
-                    <RoundBtn label='상세보기' color='bg-lightgrey' />
-                    <RoundBtn label='가방 만들기' color='bg-lightgrey' />
+            <div>
+                <div className='flex items-center justify-between py-[16.5px]'>
+                    <Content content={travel.dates} />
+                    <Content content={travel.places} />
+                    <div className='flex w-1/3 justify-center'>
+                        <RoundBtn 
+                            label='상세보기' 
+                            color='bg-lightgrey' 
+                            onClick={() => handleModalOpen(travel.places)}
+                        />
+                        <RoundBtn label='가방 만들기' color='bg-lightgrey' />
+                    </div>
                 </div>
+                {modalInfo.isOpen && (
+                    <div>
+                        <BagPackingModal setIsModal={handleModalClose} selectedPlace={modalInfo.selectedPlace}/>
+                    </div>
+                )}
             </div>
         );
     };
@@ -77,7 +110,11 @@ export default function ListComp({ travels, name }: Props) {
                 <Content content={travel.dates} />
                 <Content content={travel.places} />
                 <div className='flex w-1/3 justify-center'>
-                    <RoundBtn label='상세보기' color='bg-lightgrey' />
+                    <RoundBtn 
+                        label='상세보기' 
+                        color='bg-lightgrey' 
+                        onClick={() => setModal(true)}
+                    />
                     <RoundBtn
                         label='삭제하기'
                         color='bg-lightgrey'


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #62 - 가방만들기 상세보기 모달

📋 PR Checklist
- [ ] 여행목록 상세보기 모달창 : 완료된 일정 체크시 배경색 변환
- [ ] 내 가방 상세보기 모달창 : 챙긴 물품 체크시 취소선 
- [ ] 공통 : 모달창을 열면 모달창 상단에 해당 여행지가 잘 출력되는지

📌 유의사항
- detailschedule/LabelSchedules.tsx에 modal2 status를 추가해 모달창을 구현
- mybag/ListComp.tsx를 수정하여 상세보기 버튼을 누르면 모달창에 해당 여행지 이름이 들어가게 해놨습니다
- mybag/DetailBag.tsx에 준비물 관련 더미데이터 넣어놨습니당
- 체크박스 스타일도 피그마에 나왔듯 동그란 모양으로 구현하려 했지만 추후에 해야할 것 같네용...

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/856a9345-b03f-4329-9627-237bc3cbe3a8)
![image](https://github.com/UMC-TRIPY/web-front/assets/112371013/63de1510-67fc-4644-8c73-fa914221c6e2)

