### PR TITLE
[FIX] 환율 API 계산 안되는 이슈

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,36 +1,8 @@
-const currenyKey = process.env.NEXT_PUBLIC_EXCHANGE_KEY;
-const today = new Date();
-let date;
-const loc = today.toString().indexOf(':');
-const time = Number(today.toString().substring(loc - 2, loc));
-if (today.getDay() === 6) {
-    date = new Date(today.setDate(today.getDate() - 1));
-} else if (today.getDay() === 0) {
-    date = new Date(today.setDate(today.getDate() - 2));
-} else if (time < 11) {
-    date = new Date(today.setDate(today.getDate() - 1));
-} else {
-    date = today;
-}
-const year = date.getFullYear().toString();
-const tempMonth = (date.getMonth() + 1).toString();
-const month = tempMonth.length === 1 ? '0' + tempMonth : tempMonth;
-const day = date.getDate().toString();
-const dateValue = `${year}${month}${day}`;
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
     experimental: {
         appDir: true
-    },
-    async rewrites() {
-        return [
-            {
-                source: '/api/exchange',
-                destination: `https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=${currenyKey}&searchdate=${dateValue}&data=AP01`
-            }
-        ];
     }
 };
 

--- a/src/components/infocity/ExchangeRate.tsx
+++ b/src/components/infocity/ExchangeRate.tsx
@@ -12,24 +12,21 @@ export default function ExchangeRate({
     country: string;
 }) {
     const [cur, setCur] = useState<number>(0);
-    // 환율 대한민국 고정할거면 원화 자리에 krw 고정
-    // 나라 정보와 환율도 가져와야함 => 백엔드에서 페이지 접속할 때 넘겨줘야함
-    // 환율 가져오면 그에 따른 뒷자리도 가져와야함 => 배열로 만들어두기?
+    const currencyKey = process.env.NEXT_PUBLIC_EXCHANGE_KEY;
     useEffect(() => {
         axios
-            .get('/api/exchange')
+            .get(`http://data.fixer.io/api/latest?access_key=${currencyKey}`)
             .then((res) => {
-                const datas = [...res.data];
-                // 여행페이지에 해당하는 국가 외화 includes 안에 넣어주기
-                const tempCurrency = datas.filter((data) =>
-                    data.cur_unit.includes(currencyEn)
-                );
-                // 외화 표기에 100 표시 있으면 100으로 나눠줌
-                const other = tempCurrency[0].cur_unit.includes('(100)')
-                    ? Number(tempCurrency[0].kftc_bkpr) / 100
-                    : Number(tempCurrency[0].kftc_bkpr.replace(/,/g, ''));
-                setCur(1 / other);
-                console.log('환율 정보 : ' + 1 / other);
+                console.log(res);
+                const ko = res.data.rates.KRW;
+                const otherName = Object.keys(res.data.rates);
+                const otherValue = Object.values(res.data.rates);
+                let other;
+                otherName.filter((cur, idx) => {
+                    if (cur === currencyEn) other = otherValue[idx];
+                });
+                setCur(other / ko);
+                console.log('환율 정보 : ' + other / ko);
             })
             .catch((err) => console.log(err));
     }, []);


### PR DESCRIPTION
🚩 관련 이슈
[FIX] #67 - 환율 API 계산 안되는 이슈

📋 PR Checklist
- [ ] 뉴욕, 오사카에서 미국, 일본 환율 잘 적용되는지 확인

📌 유의사항
- env 재설정 후 해주세요!
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
