### PR TITLE
[FIX] 타입 지정, 반복문 키값, 컴포넌트 이름 대문자 변경

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,7 +8,7 @@ import ProfilePic from "@/components/mypage/profilePic";
 import FriendReq from "@/components/mypagefriend/friendReq";
 import MyFriends from "@/components/mypagefriend/myFriends";
 
-export default function mypage () {
+export default function Mypage () {
     const [activeMenu, setActiveMenu] = useState<string>('정보');
 
     const handleMenuClick = (menu: string) => {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import ConfirmBtns from "@/components/mypage/confirmBtns";
 import MyInfo from "@/components/mypage/myInfo";
 import MypageMenus from "@/components/mypage/mypageMenus";
@@ -9,7 +9,7 @@ import FriendReq from "@/components/mypagefriend/friendReq";
 import MyFriends from "@/components/mypagefriend/myFriends";
 
 export default function mypage () {
-    const [activeMenu, setActiveMenu] = useState('정보');
+    const [activeMenu, setActiveMenu] = useState<string>('정보');
 
     const handleMenuClick = (menu: string) => {
         setActiveMenu(menu);

--- a/src/app/schedulemain/page.tsx
+++ b/src/app/schedulemain/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import DetailSchedule from '@/components/detailschedule/DetailSchedule';
 import ScheduleMain from '@/components/schedulemain/scheduleMain';
 
 export default function schedule() {

--- a/src/components/schedulemain/myTravel.tsx
+++ b/src/components/schedulemain/myTravel.tsx
@@ -43,8 +43,8 @@ function MyTravel () {
                     </div>    
                 </div>
                 <div className="py-5">
-                    {currentTravels.map((travel, index) => (
-                    <div className="flex items-center justify-between py-[16.5px]">
+                    {currentTravels.map((travel) => (
+                    <div key={travel.id} className="flex items-center justify-between py-[16.5px]">
                         <div className="w-1/3 text-center">
                             {travel.dates}
                         </div>

--- a/src/components/schedulemain/myTravel.tsx
+++ b/src/components/schedulemain/myTravel.tsx
@@ -19,16 +19,16 @@ function MyTravel () {
         {id: 12, dates: "언제언제", places: "어디어디"},
         {id: 13, dates: "언제언제", places: "어디어디"},
     ]);
-    const handlePrevClick = () => {
+    const handlePrevClick = (): void => {
         setCurrentPage((prevPage) => prevPage - 1)
     };
-    const handleNextClick = () => {
+    const handleNextClick = (): void => {
         setCurrentPage((prevPage) => prevPage + 1)
     };
 
     const indexOfLastTravel = currentPage * travelsPerPage;
     const indexOfFirstTravel = indexOfLastTravel - travelsPerPage;
-    const currentTravels = travels.slice(indexOfFirstTravel, indexOfLastTravel);
+    const currentTravels = travels.slice(indexOfFirstTravel, indexOfLastTravel) as { id: number; dates: string; places: string }[];
     return (
         <div className="mx-4 mt-16">
             <div className="text-3xl font-bold mb-5">

--- a/src/components/schedulemain/scheduleMain.tsx
+++ b/src/components/schedulemain/scheduleMain.tsx
@@ -3,7 +3,7 @@ import DetailBox from "./detailBox";
 import MyTravel from "./myTravel";
 import ScheduleHeader from "./scheduleHeader";
 
-function scheduleMain () {
+function ScheduleMain () {
     const [selectedCities, setSelectedCities] = useState<string[]>([]);
     
     return (
@@ -22,4 +22,4 @@ function scheduleMain () {
     )
 }
 
-export default scheduleMain;
+export default ScheduleMain;


### PR DESCRIPTION
🚩 관련 이슈
ex) [FIX] #73 - 타입 지정, 반복문 키값, 컴포넌트 이름 대문자 변경

📋 PR Checklist
- [ ] 배포 시 오류 발생 여부 확인

📌 유의사항
useState 훅을 쓰는 컴포넌트는 모두 대문자로 시작해야해서 해당 오류가 난 것 같습니다!

✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
