### PR TITLE
[FIX] 일정 상세보기 모달 추가, 페이지네이션 5페이지씩 쪼개기, 선택일정으로 일정 바꾸기

### DIFF
--- a/src/app/info/page.tsx
+++ b/src/app/info/page.tsx
@@ -2,7 +2,7 @@
 import Image from 'next/image';
 import { BiSearch } from 'react-icons/bi';
 import { useState } from 'react';
-import SearchModal from '@/components/modal/SearchCityModal';
+import SearchCityModal from '@/components/modal/SearchCityModal';
 import Link from 'next/link';
 import { RxCross1 } from 'react-icons/rx';
 import { useRouter } from 'next/navigation';
@@ -109,7 +109,7 @@ const Page = () => {
                 </Link>
             </div>
             {modal && (
-                <SearchModal setModalState={setIsModal} results={results} />
+                <SearchCityModal setModalState={setIsModal} results={results} />
             )}
             <div className='flex self-center w-1/2 items-center mb-16'>
                 <span className='mr-2'>최근 검색어</span>

--- a/src/app/mybag/new/page.tsx
+++ b/src/app/mybag/new/page.tsx
@@ -61,7 +61,7 @@ const NewBag = () => {
             <div className='flex items-end h-36 gap-4 text-grey mb-4'>
                 <TopTab tabs={tabs} handleClickTab={handleClickTab} />
             </div>
-            <OtherSchedule href='mybag' register={false} />
+            <OtherSchedule href='mybag' register={false} top='top-[340px]' />
             <div className='h-96'>
                 <div className='flex h-full'>
                     {lastClicedTab.current ? (

--- a/src/app/newschedule/page.tsx
+++ b/src/app/newschedule/page.tsx
@@ -30,7 +30,7 @@ export default function Page() {
     useEffect(() => {
         const date: any = sessionStorage.getItem('date')?.split('~');
         const s = date[0];
-        const e = date[1].split(' ')[0];
+        const e = date[1].split(' ')[1];
         setStart(new Date(s));
         setDiffer(differenceInDays(new Date(e), new Date(s)) + 1);
     }, []);
@@ -172,7 +172,11 @@ export default function Page() {
             {/* 공통 머리글 */}
             <CommonHeader />
             {/* 다른 일정 선택 */}
-            <OtherSchedule href='schedulemain' register={false} />
+            <OtherSchedule
+                href='schedulemain'
+                register={true}
+                top='top-[0px]'
+            />
             {/* 친구 목록 */}
             <FriendList friends={friends} edit={true} />
             {/* 여행 일정 */}

--- a/src/app/summary/list/page.tsx
+++ b/src/app/summary/list/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
     };
     return (
         <div className='pt-28'>
-            <OtherSchedule href='summary' register={false} />
+            <OtherSchedule href='summary' register={false} top='top-[290px]' />
             <div className='flex'>
                 {lists.map((list, idx) => (
                     <List key={`lists${idx}`} link={list[0]} name={list[1]} />

--- a/src/app/updateschedule/page.tsx
+++ b/src/app/updateschedule/page.tsx
@@ -194,11 +194,15 @@ export default function Updateschedule() {
     };
 
     return (
-        <div className='mt-20 p-20'>
+        <div className='mt-20 py-20'>
             {/* 공통 머리글 */}
             <CommonHeader />
             {/* 다른 일정 선택 */}
-            <OtherSchedule href='schedulemain' register={true} />
+            <OtherSchedule
+                href='schedulemain'
+                register={false}
+                top='top-[545px]'
+            />
             {/* 친구 목록 */}
             <FriendList friends={[]} edit={true} />
             {/* 여행 일정 */}

--- a/src/components/detailschedule/DetailSchedule.tsx
+++ b/src/components/detailschedule/DetailSchedule.tsx
@@ -25,7 +25,11 @@ export default function DetailSchedule() {
             {/* 공통 머리글 */}
             <CommonHeader />
             {/* 다른 일정 선택 */}
-            <OtherSchedule href='schedulemain' register={true} />
+            <OtherSchedule
+                href='schedulemain'
+                register={false}
+                top='top-[460px]'
+            />
             {/* 친구 목록 */}
             <FriendList friends={friends} edit={false} />
             {/* 여행 일정 */}

--- a/src/components/detailschedule/LabelSchedules.tsx
+++ b/src/components/detailschedule/LabelSchedules.tsx
@@ -113,9 +113,13 @@ export default function LabelSchedules({ status }: ILabelScheduleProps) {
                             {schedule.todos.map((todo, idx) => (
                                 <div
                                     key={idx}
-                                    className={`flex items-center justify-between border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2 ${
-                                        todo.color
-                                    } ${todo.checked ? 'bg-lightgrey' : ''}`}
+                                    className='flex items-center justify-between border border-lightgrey border-l-8 rounded-lg p-2 pl-7 mb-2'
+                                    style={{
+                                        borderLeftColor: todo.color,
+                                        backgroundColor: todo.checked
+                                            ? '#E5E5E5'
+                                            : ''
+                                    }}
                                 >
                                     <div>
                                         <div className='text-xs text-grey pb-2'>

--- a/src/components/detailschedule/OtherSchedule.tsx
+++ b/src/components/detailschedule/OtherSchedule.tsx
@@ -1,39 +1,79 @@
+import { checkLists } from '@/apis/travellists/check';
 import { updateLists } from '@/apis/travellists/update';
 import { format } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import differenceInDays from 'date-fns/differenceInDays';
+import SelectScheduleModal from '../modal/SelectScheduleModal';
 
 export default function OtherSchedule({
     href,
-    register
+    register,
+    top
 }: {
     href: string;
     register: boolean;
+    top: string;
 }) {
-    const [date, setDates] = useState<string>('');
+    const [date, setDate] = useState<string>('');
     const [place, setPlace] = useState<string>('');
     const [start, setStart] = useState<any>();
     const [end, setEnd] = useState<any>();
+    const [schedules, setSchedules] = useState<any>();
+    const [modal, setModal] = useState<boolean>(false);
+
     useEffect(() => {
         const d = sessionStorage.getItem('date');
         const p = sessionStorage.getItem('place');
 
         const s: any = d?.split('~')[0];
-        const e: any = d?.split('~')[1].split(' ')[0];
+        const e: any = d?.split('~')[1].split(' ')[1];
+
         setStart(new Date(s));
         setEnd(new Date(e));
-        setDates(!d ? '' : d);
+        setDate(!d ? '' : d);
         setPlace(!p ? '' : p);
+        checkLists()
+            .then((res) => {
+                let tmp: any[] = [];
+                res.map((d: any, idx: number) => {
+                    const departureDate =
+                        d.departureDate === '0000-00-00'
+                            ? new Date()
+                            : new Date(d.departureDate.slice(0, 10));
+                    const arrivalDate = new Date(d.arrivalDate.slice(0, 10));
+                    const difference = differenceInDays(
+                        arrivalDate,
+                        departureDate
+                    );
+                    tmp.push({
+                        id: d.plan_index,
+                        dates: `${format(
+                            departureDate,
+                            'yyyy.MM.dd'
+                        )} ~ ${format(arrivalDate, 'yyyy.MM.dd')} (${
+                            difference === 0
+                                ? '당일치기'
+                                : `${difference}박 ${difference + 1}일`
+                        })`,
+                        places: d.city_name === null ? '미정' : d.city_name
+                    });
+                });
+                setSchedules(tmp);
+            })
+            .catch((err) => console.log(err));
     }, []);
     const router = useRouter();
 
-    useEffect(() => {}, []);
+    // useEffect(() => {
+    //     console.log('dd');
+    // }, []);
     const onClick = () => {
         if (!place) {
             alert('여행 지역을 입력해주세요.');
             return;
         }
-        if (!register) {
+        if (register) {
             const datas = {
                 cityname: place,
                 departureDate: format(start, 'yyyy-MM-dd'),
@@ -45,20 +85,34 @@ export default function OtherSchedule({
     };
     return (
         <div className='flex justify-between '>
-            <div className='border border-lightgrey w-[51%] py-5 px-5 rounded-lg text-xl'>
+            <div
+                className={`border border-lightgrey min-w-[656px] py-5 px-5 rounded-lg text-xl ${
+                    register ? 'cursor-default' : 'cursor-pointer'
+                }`}
+                onClick={() => setModal(true)}
+            >
                 <span className='mr-7 text-grey'>선택 일정</span>
                 <span>{date}</span>
             </div>
-            <div className='border border-lightgrey w-[31%] py-5 px-5 rounded-lg text-xl flex'>
+            <div className='border border-lightgrey min-w-[400px] py-5 px-5 rounded-lg text-xl flex cursor-default'>
                 <span className='text-grey mr-7'>여행 지역</span>
                 <span>{place}</span>
             </div>
             <button
-                className='w-[16%] rounded-lg text-xl bg-primary border-primary'
+                className='min-w-[200px] rounded-lg text-xl bg-primary border-primary'
                 onClick={onClick}
             >
-                {!register ? '변경사항 저장' : '다른 일정 선택'}
+                {register ? '변경사항 저장' : '다른 일정 선택'}
             </button>
+            {modal && !register && (
+                <SelectScheduleModal
+                    setModalState={setModal}
+                    schedules={schedules}
+                    setDate={setDate}
+                    setPlace={setPlace}
+                    top={top}
+                />
+            )}
         </div>
     );
 }

--- a/src/components/maincommunity/Pagination.tsx
+++ b/src/components/maincommunity/Pagination.tsx
@@ -8,9 +8,14 @@ export default function Pagination({
     setCurrent: React.Dispatch<React.SetStateAction<number>>;
 }) {
     let pages = [];
+
     for (let i = 1; i <= totalPages; i++) {
         pages.push(i);
     }
+    let slicingPages = pages.slice(
+        Math.floor((current - 1) / 5) * 5,
+        (Math.floor((current - 1) / 5) + 1) * 5
+    );
 
     const prevPage = () => {
         setCurrent((n) => n - 1);
@@ -30,11 +35,14 @@ export default function Pagination({
                 >
                     {'<'}
                 </button>
-                {pages.map((p, idx) => (
+                {slicingPages.map((p, idx) => (
                     <button
                         key={`pagenum${idx}`}
                         className={`mx-3 ${
-                            current - 1 === idx ? 'font-bold' : 'font-normal'
+                            current - 1 ===
+                            idx + Math.floor((current - 1) / 5) * 5
+                                ? 'font-bold'
+                                : 'font-normal'
                         }`}
                         onClick={() => setCurrent(p)}
                     >

--- a/src/components/modal/FixedSearchCityModal.tsx
+++ b/src/components/modal/FixedSearchCityModal.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import Portal from './Portal';
 import Link from 'next/link';
 
-export default function Scompo({
+export default function FixedSearchCityModal({
     setIsModal,
     results
 }: {

--- a/src/components/modal/ScheduleDetailModal.tsx
+++ b/src/components/modal/ScheduleDetailModal.tsx
@@ -3,10 +3,11 @@ import LabelSchedules from '../detailschedule/LabelSchedules';
 import Modal from './Modal';
 
 const ScheduleDetailModal = ({ setIsModal }: any) => {
+    const place = sessionStorage.getItem('place');
     return (
         <Modal
             modalMode={0}
-            title='일정 상세보기'
+            title={`${place} 일정 상세보기`}
             setModalState={setIsModal}
             onClickCompleteButton={() => setIsModal(false)}
             completeText=''

--- a/src/components/modal/SearchCityModal.tsx
+++ b/src/components/modal/SearchCityModal.tsx
@@ -7,7 +7,7 @@ type Props = {
     results: [string, string][];
 };
 
-export default function SearchModal({ setModalState, results }: Props) {
+export default function SearchCityModal({ setModalState, results }: Props) {
     useEffect(() => {
         document.body.style.overflowX = 'hidden';
     });

--- a/src/components/modal/SelectScheduleModal.tsx
+++ b/src/components/modal/SelectScheduleModal.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import Portal from '@/components/modal/Portal';
+
+type Props = {
+    setModalState: React.Dispatch<React.SetStateAction<boolean>>;
+    schedules: {
+        id: number;
+        dates: string;
+        places: string;
+    }[];
+    setDate: any;
+    setPlace: any;
+    top: string;
+};
+
+export default function SelectScheduleModal({
+    setModalState,
+    schedules,
+    setDate,
+    setPlace,
+    top
+}: Props) {
+    useEffect(() => {
+        document.body.style.overflowX = 'hidden';
+    });
+    return (
+        <Portal selector='#body'>
+            <div>
+                <div
+                    className='absolute top-0 left-0 w-screen h-screen'
+                    onClick={() => {
+                        setModalState(false);
+                    }}
+                ></div>
+                <div
+                    className={`absolute flex flex-col rounded-lg max-h-56 bg-white z-101 shadow-md max-w-[653px] min-w-[656px] ${top} ${
+                        schedules.length > 4
+                            ? 'overflow-y-scroll'
+                            : 'overflow-y-hidden'
+                    }`}
+                >
+                    {schedules.map(
+                        (
+                            schedule: {
+                                id: number;
+                                dates: string;
+                                places: string;
+                            },
+                            idx: number
+                        ) => (
+                            <div
+                                key={`schedule${idx}`}
+                                className='flex py-4 px-8 border-y border-morelightgrey cursor-pointer'
+                                onClick={() => {
+                                    sessionStorage.setItem(
+                                        'date',
+                                        schedule.dates
+                                    );
+                                    sessionStorage.setItem(
+                                        'place',
+                                        schedule.places
+                                    );
+                                    setDate(schedule.dates);
+                                    setPlace(schedule.places);
+                                    setModalState(false);
+                                }}
+                            >
+                                <div className='w-2/5'>{schedule.places}</div>
+                                <div className='w-full'>{schedule.dates}</div>
+                            </div>
+                        )
+                    )}
+                </div>
+            </div>
+        </Portal>
+    );
+}

--- a/src/components/mypage/MyBagList.tsx
+++ b/src/components/mypage/MyBagList.tsx
@@ -5,6 +5,7 @@ import RoundBtn from '../layout/roundBtn';
 import differenceInDays from 'date-fns/differenceInDays';
 import format from 'date-fns/format';
 import Pagination from '../maincommunity/Pagination';
+import ScheduleDetailModal from '../modal/ScheduleDetailModal';
 
 interface Props {
     id: number;
@@ -15,6 +16,7 @@ interface Props {
 export default function MyBagList() {
     const [contents, setContents] = useState<any>([]);
     const router = useRouter();
+    const [modal, setModal] = useState<boolean>(false);
     useEffect(() => {
         checkLists().then((res) => {
             let tmp: any[] = [];
@@ -85,6 +87,17 @@ export default function MyBagList() {
                                     <RoundBtn
                                         label='상세보기'
                                         color='bg-lightgrey'
+                                        onClick={() => {
+                                            sessionStorage.setItem(
+                                                'place',
+                                                data.places
+                                            );
+                                            sessionStorage.setItem(
+                                                'date',
+                                                data.dates
+                                            );
+                                            setModal(true);
+                                        }}
                                     />
                                     <RoundBtn
                                         label='삭제하기'
@@ -101,6 +114,7 @@ export default function MyBagList() {
                 current={current}
                 setCurrent={setCurrent}
             />
+            {modal && <ScheduleDetailModal setIsModal={setModal} />}
         </div>
     );
 }

--- a/src/components/mypage/MyTravelList.tsx
+++ b/src/components/mypage/MyTravelList.tsx
@@ -5,6 +5,7 @@ import RoundBtn from '../layout/roundBtn';
 import differenceInDays from 'date-fns/differenceInDays';
 import format from 'date-fns/format';
 import Pagination from '../maincommunity/Pagination';
+import ScheduleDetailModal from '../modal/ScheduleDetailModal';
 
 interface Props {
     id: number;
@@ -14,6 +15,7 @@ interface Props {
 
 export default function MyTravelList({ option }: { option: string }) {
     const [contents, setContents] = useState<any>([]);
+    const [modal, setModal] = useState<boolean>(false);
     const router = useRouter();
     useEffect(() => {
         checkLists().then((res) => {
@@ -85,6 +87,17 @@ export default function MyTravelList({ option }: { option: string }) {
                                     <RoundBtn
                                         label='상세보기'
                                         color='bg-lightgrey'
+                                        onClick={() => {
+                                            sessionStorage.setItem(
+                                                'place',
+                                                data.places
+                                            );
+                                            sessionStorage.setItem(
+                                                'date',
+                                                data.dates
+                                            );
+                                            setModal(true);
+                                        }}
                                     />
                                     <RoundBtn
                                         label={option}
@@ -116,6 +129,7 @@ export default function MyTravelList({ option }: { option: string }) {
                 current={current}
                 setCurrent={setCurrent}
             />
+            {modal && <ScheduleDetailModal setIsModal={setModal} />}
         </div>
     );
 }

--- a/src/components/schedulemain/detailBox.tsx
+++ b/src/components/schedulemain/detailBox.tsx
@@ -125,7 +125,7 @@ function DetailBox({ selectedCities, setSelectedCities }: DetailBoxProps) {
         const start = format(startDate, 'yyyy.MM.dd');
         const end = format(endDate, 'yyyy.MM.dd');
         const difference = differenceInDays(endDate, startDate) + 1;
-        const dates = `${start}~${end} (${difference - 1}박 ${difference}일)`;
+        const dates = `${start} ~ ${end} (${difference - 1}박 ${difference}일)`;
         sessionStorage.setItem('date', dates);
     };
     return (

--- a/src/components/summary/CommonHeader.tsx
+++ b/src/components/summary/CommonHeader.tsx
@@ -5,7 +5,7 @@ export default function CommonHeader({ path }: { path: string }) {
     return (
         <>
             <Menu path={path} />
-            <OtherSchedule href='schedulemain' register={false} />
+            <OtherSchedule href='summary' register={false} top='top-[285px]' />
         </>
     );
 }


### PR DESCRIPTION
🚩 관련 이슈
[FIX] #130 - 일정 상세보기 모달 추가, 페이지네이션 5페이지씩 쪼개기, 선택일정으로 일정 바꾸기

📋 PR Checklist
- [x] 일정 상세보기 모달 추가
- [x] 페이지네이션 5페이지씩 쪼개기
- [x] 선택일정으로 일정 바꾸기

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
